### PR TITLE
fix: Fix the linter handling numeric headers

### DIFF
--- a/dev-tools/linter/main.cpp
+++ b/dev-tools/linter/main.cpp
@@ -214,7 +214,7 @@ main(int argc, char **argv) {
                 std::istreambuf_iterator<char>()
             };
             std::regex include_guard_expression(
-                "(^|\n) *# *ifndef *([a-zA-Z_/\\. ]+)");
+                "(^|\n) *# *ifndef *([a-zA-Z0-9_/\\. ]+)");
             std::smatch include_guard_match;
             if (std::regex_search(
                     file_content,

--- a/include/small/string.hpp
+++ b/include/small/string.hpp
@@ -5127,4 +5127,4 @@ namespace std {
     };
 } // namespace std
 
-#endif // SMALL_UTF8_STRING_H
+#endif // SMALL_STRING_HPP


### PR DESCRIPTION
As discussed here #8. I started with a simple addition to linter's regex. I'll check the C++ grammar for valid chars in macros to see if we aren't handling something.