### PR TITLE
Make sure destructor gets called when erasing range

### DIFF
--- a/include/small/vector.hpp
+++ b/include/small/vector.hpp
@@ -1069,13 +1069,15 @@ namespace small {
             if (first == last) {
                 return unconst(first);
             }
-            if constexpr (is_relocatable_v<value_type> && using_std_allocator) {
-                // Directly destroy elements before mem moving
-                if constexpr (!std::is_trivially_destructible_v<T>) {
-                    for (auto it = first; it != last; ++it) {
-                        it->~value_type();
-                    }
+            
+            // Directly destroy elements before mem moving
+            if constexpr (!std::is_trivially_destructible_v<T>) {
+                for (auto it = first; it != last; ++it) {
+                    it->~value_type();
                 }
+            }
+            
+            if constexpr (is_relocatable_v<value_type> && using_std_allocator) {
                 // Move elements directly in memory
                 const auto n_erase = last - first;
                 const auto n_after_erase = cend() - last;


### PR DESCRIPTION
Make sure destructor of underlying objects gets called when erasing range. In some cases destructor was not called, leading to memory leaks and other problems.