### PR TITLE
Add `<cstdint>` for `uintptr_t`

### DIFF
--- a/include/small/detail/exception/scope_guard.hpp
+++ b/include/small/detail/exception/scope_guard.hpp
@@ -9,6 +9,7 @@
 #define SMALL_DETAIL_EXCEPTION_SCOPE_GUARD_HPP
 
 #include <small/detail/exception/throw.hpp>
+#include <cstdint> // uintptr_t
 #include <functional>
 #include <iostream>
 #include <utility>


### PR DESCRIPTION
Fails to compile under `glibc-2.37`.

Originally discovered from https://github.com/transmission/transmission/issues/5727.