### PR TITLE
fix: explicitly include <cstdint> in scope-guard for uintptr_t

### DIFF
--- a/include/small/detail/exception/scope_guard.hpp
+++ b/include/small/detail/exception/scope_guard.hpp
@@ -9,6 +9,7 @@
 #define SMALL_DETAIL_EXCEPTION_SCOPE_GUARD_HPP
 
 #include <small/detail/exception/throw.hpp>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <utility>


### PR DESCRIPTION
Fixes [a minor build issue](https://github.com/transmission/transmission/issues/5727) reported by a user building Transmission with `<small/vector.hpp>`:

> /home/gary/Documents/GitHub/transmission-primary/third-party/small/include/small/detail/exception/scope_guard.hpp:14:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’? 13 | #include <iostream> +++ |+#include <cstdint> 14 | #include <utility> make[2]: *** [libtransmission/CMakeFiles/transmission.dir/build.make:300: libtransmission/CMakeFiles/transmission.dir/file-piece-map.cc.o] Error 1 make[1]: *** [CMakeFiles/Makefile2:571: libtransmission/CMakeFiles/transmission.dir/all] Error 2 make: *** [Makefile:166: all] Error 2

Also, @alandefreitas I think this is the first time I've reached out, so I also wanted to say thanks for writing `small`! It seems very well-thought out for small containers, both when aggregating them in classes and when making short-term containers on the stack. :green_heart: 