### PR TITLE
fix: `vector.hpp` compilation error with llvm headers

### DIFF
--- a/include/small/vector.hpp
+++ b/include/small/vector.hpp
@@ -23,6 +23,7 @@
 #include <limits>
 #include <new>
 #include <ratio>
+#include <vector>
 
 namespace small {
     /// \brief Vector of elements with a buffer for small vectors

--- a/include/small/vector.hpp
+++ b/include/small/vector.hpp
@@ -1809,7 +1809,7 @@ namespace small {
     template <
         class T,
         size_t N
-        = (std::max)((sizeof(std::vector<T>) * 2) / sizeof(T), std::size_t(5)),
+        = (std::max)((24 * 2) / sizeof(T), std::size_t(5)),
         class Allocator = std::allocator<T>,
         class SizeType = size_t>
     using max_size_vector = vector<T, N, Allocator, std::false_type, SizeType>;
@@ -1817,7 +1817,7 @@ namespace small {
     template <
         class T,
         size_t N
-        = (std::max)((sizeof(std::vector<T>) * 2) / sizeof(T), std::size_t(5)),
+        = (std::max)((24 * 2) / sizeof(T), std::size_t(5)),
         class Allocator = std::allocator<T>,
         class SizeType = size_t>
     using inline_vector = vector<T, N, Allocator, std::true_type, SizeType>;

--- a/include/small/vector.hpp
+++ b/include/small/vector.hpp
@@ -23,7 +23,6 @@
 #include <limits>
 #include <new>
 #include <ratio>
-#include <vector>
 
 namespace small {
     /// \brief Vector of elements with a buffer for small vectors


### PR DESCRIPTION
Fails to build on some systems.

```
In file included from /root/small-ftbfs/main.cpp:4:
/root/small-ftbfs/build_deb/_deps/small-src/source/small/vector.h:1405:45: error: implicit instantiation of undefined template 'std::vector<std::pair<int, int>>'
    template <class T, size_t N = std::max((sizeof(std::vector<T>) * 2) / sizeof(T), std::size_t(5)),
                                            ^
/root/small-ftbfs/main.cpp:6:20: note: in instantiation of default argument for 'max_size_vector<std::pair<int, int>>' required here
using Vec = small::max_size_vector<std::pair<int, int>>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
```