### PR TITLE
fix: only accept base pointer in `pointer_wrapper` comparison operators

### DIFF
--- a/include/small/detail/iterator/pointer_wrapper.hpp
+++ b/include/small/detail/iterator/pointer_wrapper.hpp
@@ -252,63 +252,63 @@ namespace small {
             return !(y < x);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator==(const pointer_wrapper<Iter> &x, const BaseIter &y) noexcept {
+        operator==(const pointer_wrapper<Iter> &x, Iter y) noexcept {
             return x.base() == y;
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator!=(const pointer_wrapper<Iter> &x, const BaseIter &y) noexcept {
+        operator!=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator>(const pointer_wrapper<Iter> &x, const BaseIter &y) noexcept {
+        operator>(const pointer_wrapper<Iter> &x, Iter y) noexcept {
             return y < x;
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator>=(const pointer_wrapper<Iter> &x, const BaseIter &y) noexcept {
+        operator>=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator<=(const pointer_wrapper<Iter> &x, const BaseIter &y) noexcept {
+        operator<=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
             return !(y < x);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator==(const BaseIter &x, const pointer_wrapper<Iter> &y) noexcept {
+        operator==(Iter x, const pointer_wrapper<Iter> &y) noexcept {
             return x.base() == y.base();
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator!=(const BaseIter &x, const pointer_wrapper<Iter> &y) noexcept {
+        operator!=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator>(const BaseIter &x, const pointer_wrapper<Iter> &y) noexcept {
+        operator>(Iter x, const pointer_wrapper<Iter> &y) noexcept {
             return y < x;
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator>=(const BaseIter &x, const pointer_wrapper<Iter> &y) noexcept {
+        operator>=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter, class BaseIter>
+        template <class Iter>
         inline constexpr bool
-        operator<=(const BaseIter &x, const pointer_wrapper<Iter> &y) noexcept {
+        operator<=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
             return !(y < x);
         }
 

--- a/include/small/detail/iterator/pointer_wrapper.hpp
+++ b/include/small/detail/iterator/pointer_wrapper.hpp
@@ -146,186 +146,186 @@ namespace small {
 
             public /* friends */:
             /// \brief Get distance between iterators
-            template <class Iter1, class Iter2>
+            template <class Pointer1, class Pointer2>
             constexpr friend auto
             operator-(
-                const pointer_wrapper<Iter1> &x,
-                const pointer_wrapper<Iter2> &y) noexcept
+                const pointer_wrapper<Pointer1> &x,
+                const pointer_wrapper<Pointer2> &y) noexcept
                 -> decltype(x.base() - y.base());
 
             /// \brief Sum iterators
-            template <class Iter1>
-            constexpr friend pointer_wrapper<Iter1> operator+(
-                typename pointer_wrapper<Iter1>::difference_type,
-                pointer_wrapper<Iter1>) noexcept;
+            template <class Pointer1>
+            constexpr friend pointer_wrapper<Pointer1> operator+(
+                typename pointer_wrapper<Pointer1>::difference_type,
+                pointer_wrapper<Pointer1>) noexcept;
 
         private:
             /// Base pointer
             iterator_type base_;
         };
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator==(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return x.base() == y.base();
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator!=(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator<(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return x.base() < y.base();
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator>(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return y < x;
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator>=(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr bool
         operator<=(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return !(y < x);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
         operator==(
-            const pointer_wrapper<Iter> &x,
-            const pointer_wrapper<Iter> &y) noexcept {
+            const pointer_wrapper<Pointer> &x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return x.base() == y.base();
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
         operator!=(
-            const pointer_wrapper<Iter> &x,
-            const pointer_wrapper<Iter> &y) noexcept {
+            const pointer_wrapper<Pointer> &x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
         operator>(
-            const pointer_wrapper<Iter> &x,
-            const pointer_wrapper<Iter> &y) noexcept {
+            const pointer_wrapper<Pointer> &x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return y < x;
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
         operator>=(
-            const pointer_wrapper<Iter> &x,
-            const pointer_wrapper<Iter> &y) noexcept {
+            const pointer_wrapper<Pointer> &x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
         operator<=(
-            const pointer_wrapper<Iter> &x,
-            const pointer_wrapper<Iter> &y) noexcept {
+            const pointer_wrapper<Pointer> &x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(y < x);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator==(const pointer_wrapper<Iter> &x, Iter y) noexcept {
+        operator==(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
             return x.base() == y;
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator!=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
+        operator!=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator>(const pointer_wrapper<Iter> &x, Iter y) noexcept {
+        operator>(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
             return y < x;
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator>=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
+        operator>=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator<=(const pointer_wrapper<Iter> &x, Iter y) noexcept {
+        operator<=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
             return !(y < x);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator==(Iter x, const pointer_wrapper<Iter> &y) noexcept {
+        operator==(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
             return x.base() == y.base();
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator!=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
+        operator!=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
             return !(x == y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator>(Iter x, const pointer_wrapper<Iter> &y) noexcept {
+        operator>(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
             return y < x;
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator>=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
+        operator>=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
             return !(x < y);
         }
 
-        template <class Iter>
+        template <class Pointer>
         inline constexpr bool
-        operator<=(Iter x, const pointer_wrapper<Iter> &y) noexcept {
+        operator<=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
             return !(y < x);
         }
 
-        template <class Iter1, class Iter2>
+        template <class Pointer1, class Pointer2>
         inline constexpr auto
         operator-(
-            const pointer_wrapper<Iter1> &x,
-            const pointer_wrapper<Iter2> &y) noexcept
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept
             -> decltype(x.base() - y.base()) {
             return x.base() - y.base();
         }
 
-        template <class Iter>
-        inline constexpr pointer_wrapper<Iter>
+        template <class Pointer>
+        inline constexpr pointer_wrapper<Pointer>
         operator+(
-            typename pointer_wrapper<Iter>::difference_type n,
-            pointer_wrapper<Iter> x) noexcept {
+            typename pointer_wrapper<Pointer>::difference_type n,
+            pointer_wrapper<Pointer> x) noexcept {
             x += n;
             return x;
         }

--- a/include/small/detail/iterator/pointer_wrapper.hpp
+++ b/include/small/detail/iterator/pointer_wrapper.hpp
@@ -165,7 +165,7 @@ namespace small {
             iterator_type base_;
         };
 
-        template <class Pointer1, class Pointer2>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator==(
             const pointer_wrapper<Pointer1> &x,
@@ -173,7 +173,7 @@ namespace small {
             return x.base() == y.base();
         }
 
-        template <class Pointer1, class Pointer2>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator!=(
             const pointer_wrapper<Pointer1> &x,
@@ -181,7 +181,7 @@ namespace small {
             return !(x == y);
         }
 
-        template <class Pointer1, class Pointer2>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator<(
             const pointer_wrapper<Pointer1> &x,
@@ -189,7 +189,7 @@ namespace small {
             return x.base() < y.base();
         }
 
-        template <class Pointer1, class Pointer2>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator>(
             const pointer_wrapper<Pointer1> &x,
@@ -197,15 +197,7 @@ namespace small {
             return y < x;
         }
 
-        template <class Pointer1, class Pointer2>
-        inline constexpr bool
-        operator>=(
-            const pointer_wrapper<Pointer1> &x,
-            const pointer_wrapper<Pointer2> &y) noexcept {
-            return !(x < y);
-        }
-
-        template <class Pointer1, class Pointer2>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator<=(
             const pointer_wrapper<Pointer1> &x,
@@ -213,44 +205,12 @@ namespace small {
             return !(y < x);
         }
 
-        template <class Pointer>
-        inline constexpr bool
-        operator==(
-            const pointer_wrapper<Pointer> &x,
-            const pointer_wrapper<Pointer> &y) noexcept {
-            return x.base() == y.base();
-        }
-
-        template <class Pointer>
-        inline constexpr bool
-        operator!=(
-            const pointer_wrapper<Pointer> &x,
-            const pointer_wrapper<Pointer> &y) noexcept {
-            return !(x == y);
-        }
-
-        template <class Pointer>
-        inline constexpr bool
-        operator>(
-            const pointer_wrapper<Pointer> &x,
-            const pointer_wrapper<Pointer> &y) noexcept {
-            return y < x;
-        }
-
-        template <class Pointer>
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr bool
         operator>=(
-            const pointer_wrapper<Pointer> &x,
-            const pointer_wrapper<Pointer> &y) noexcept {
+            const pointer_wrapper<Pointer1> &x,
+            const pointer_wrapper<Pointer2> &y) noexcept {
             return !(x < y);
-        }
-
-        template <class Pointer>
-        inline constexpr bool
-        operator<=(
-            const pointer_wrapper<Pointer> &x,
-            const pointer_wrapper<Pointer> &y) noexcept {
-            return !(y < x);
         }
 
         template <class Pointer>
@@ -271,18 +231,18 @@ namespace small {
 
         template <class Pointer>
         inline constexpr bool
-        operator>(
+        operator<(
             const pointer_wrapper<Pointer> &x,
             ptr_to_const_t<Pointer> y) noexcept {
-            return y < x;
+            return x.base() < y;
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator>=(
+        operator>(
             const pointer_wrapper<Pointer> &x,
             ptr_to_const_t<Pointer> y) noexcept {
-            return !(x < y);
+            return y < x.base();
         }
 
         template <class Pointer>
@@ -295,10 +255,18 @@ namespace small {
 
         template <class Pointer>
         inline constexpr bool
+        operator>=(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
+            return !(x < y);
+        }
+
+        template <class Pointer>
+        inline constexpr bool
         operator==(
             ptr_to_const_t<Pointer> x,
             const pointer_wrapper<Pointer> &y) noexcept {
-            return x.base() == y.base();
+            return x == y.base();
         }
 
         template <class Pointer>
@@ -319,10 +287,10 @@ namespace small {
 
         template <class Pointer>
         inline constexpr bool
-        operator>=(
+        operator<(
             ptr_to_const_t<Pointer> x,
             const pointer_wrapper<Pointer> &y) noexcept {
-            return !(x < y);
+            return y > x;
         }
 
         template <class Pointer>
@@ -333,7 +301,15 @@ namespace small {
             return !(y < x);
         }
 
-        template <class Pointer1, class Pointer2>
+        template <class Pointer>
+        inline constexpr bool
+        operator>=(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
+            return !(x < y);
+        }
+
+        template <class Pointer1, class Pointer2 = Pointer1>
         inline constexpr auto
         operator-(
             const pointer_wrapper<Pointer1> &x,

--- a/include/small/detail/iterator/pointer_wrapper.hpp
+++ b/include/small/detail/iterator/pointer_wrapper.hpp
@@ -8,6 +8,7 @@
 #ifndef SMALL_DETAIL_ITERATOR_POINTER_WRAPPER_HPP
 #define SMALL_DETAIL_ITERATOR_POINTER_WRAPPER_HPP
 
+#include <small/detail/traits/ptr_to_const.hpp>
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
@@ -254,61 +255,81 @@ namespace small {
 
         template <class Pointer>
         inline constexpr bool
-        operator==(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
+        operator==(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
             return x.base() == y;
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator!=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
+        operator!=(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
             return !(x == y);
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator>(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
+        operator>(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
             return y < x;
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator>=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
+        operator>=(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
             return !(x < y);
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator<=(const pointer_wrapper<Pointer> &x, Pointer y) noexcept {
+        operator<=(
+            const pointer_wrapper<Pointer> &x,
+            ptr_to_const_t<Pointer> y) noexcept {
             return !(y < x);
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator==(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
+        operator==(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return x.base() == y.base();
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator!=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
+        operator!=(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(x == y);
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator>(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
+        operator>(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return y < x;
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator>=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
+        operator>=(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(x < y);
         }
 
         template <class Pointer>
         inline constexpr bool
-        operator<=(Pointer x, const pointer_wrapper<Pointer> &y) noexcept {
+        operator<=(
+            ptr_to_const_t<Pointer> x,
+            const pointer_wrapper<Pointer> &y) noexcept {
             return !(y < x);
         }
 

--- a/include/small/detail/traits/ptr_to_const.hpp
+++ b/include/small/detail/traits/ptr_to_const.hpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2024 Yat Ho (lagoho7@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef SMALL_DETAIL_TRAITS_PTR_TO_CONST_HPP
+#define SMALL_DETAIL_TRAITS_PTR_TO_CONST_HPP
+
+#include <type_traits>
+
+namespace small {
+    namespace detail {
+        /// Convert a pointer to pointer-to-const
+        template <typename T, typename = std::enable_if_t<std::is_pointer_v<T>>>
+        using ptr_to_const = std::add_pointer<
+            std::add_const_t<std::remove_pointer_t<T>>>;
+
+        template <typename T>
+        using ptr_to_const_t = typename ptr_to_const<T>::type;
+    } // namespace detail
+} // namespace small
+
+#endif // SMALL_DETAIL_TRAITS_PTR_TO_CONST_HPP

--- a/test/unit/string_small_vector.cpp
+++ b/test/unit/string_small_vector.cpp
@@ -206,6 +206,36 @@ TEST_CASE("String Vector") {
 
     SECTION("Iterators") {
         vector<std::string, 5> a = { "one", "two", "three" };
+        auto iter = a.begin();
+
+        // LegacyContiguousIterator
+        REQUIRE(*(a.begin() + 2) == *(std::addressof(*a.begin()) + 2));
+
+        // LegacyRandomAccessIterator
+        REQUIRE((iter += 2) == a.begin() + 2);
+        REQUIRE(a.begin() + 1 == 1 + a.begin());
+        REQUIRE((iter -= 2) == a.begin());
+        REQUIRE(a.end() - 2 == a.begin() + 1);
+        REQUIRE(a.end() - a.begin() == 3);
+        REQUIRE(a.begin()[1] == "two");
+        REQUIRE(a.end()[-1] == "three");
+
+        REQUIRE(a.begin() == a.begin());
+        REQUIRE(a.begin() != a.begin() + 2);
+        REQUIRE(a.begin() < a.begin() + 2);
+        REQUIRE(a.begin() + 2 > a.begin());
+
+        // LegacyBidirectionalIterator + LegacyForwardIterator
+        iter = a.begin() + 1;
+        REQUIRE(--iter == a.begin());
+        REQUIRE(iter++ == a.begin());
+        REQUIRE(iter-- == a.begin() + 1);
+        iter = a.begin() + 1;
+        REQUIRE(*iter-- == "two");
+
+        // LegacyInputIterator/LegacyIterator
+        iter = a.begin();
+        REQUIRE(++iter == a.begin() + 1);
 
         REQUIRE(a.begin() == a.data());
         REQUIRE(a.end() == a.data() + a.size());
@@ -224,6 +254,17 @@ TEST_CASE("String Vector") {
 
         REQUIRE(*a.crbegin() == "three");
         REQUIRE(*std::prev(a.crend()) == "one");
+
+        // Custom comparison operators
+        REQUIRE(a.begin() == a.data());
+        REQUIRE(a.begin() != a.data() + 2);
+        REQUIRE(a.begin() < a.data() + 2);
+        REQUIRE(a.begin() + 2 > a.data());
+
+        REQUIRE(a.data() == a.begin());
+        REQUIRE(a.data() != a.begin() + 2);
+        REQUIRE(a.data() < a.begin() + 2);
+        REQUIRE(a.data() + 2 > a.begin());
     }
 
     SECTION("Capacity") {


### PR DESCRIPTION
Fixes #31.

Tested with the test program in the original issue.