### PR TITLE
feat: `associative_vector` rework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,10 @@ jobs:
             install_dir: "/usr/local/"
           }
           - {
-            name: "Ubuntu/20.04/Static/X64/fsanitize",
-            os: ubuntu-20.04,
+            name: "Ubuntu/22.04/Static/X64/fsanitize",
+            os: ubuntu-22.04,
             config: Debug,
-            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/bin/clang-12 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-12 -DCMAKE_C_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined' -DCMAKE_CXX_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined'",
+            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -DCMAKE_C_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined' -DCMAKE_CXX_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined'",
             sudocmd: "sudo",
             artifact_name: "Linux",
             cores: 2,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,8 @@ jobs:
             install_dir: "/usr/local/"
           }
           - {
-            name: "MacOSX/10.15/Static/X64/Release",
-            os: macos-10.15,
+            name: "MacOSX/12/Static/X64/Release",
+            os: macos-12,
             config: Release,
             cmake_extra_args: "-DCMAKE_CXX_FLAGS=\"-O2\"",
             sudocmd: "sudo",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,17 @@ jobs:
             name: "Ubuntu/20.04/Static/X64/Release",
             os: ubuntu-20.04,
             config: Release,
-            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/bin/gcc-10 -DCMAKE_CXX_COMPILER=/usr/bin/g++-10  -DCMAKE_CXX_FLAGS=\"-O2\"",
+            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/bin/gcc-10 -DCMAKE_CXX_COMPILER=/usr/bin/g++-10 -DCMAKE_CXX_FLAGS=\"-O2\"",
+            sudocmd: "sudo",
+            artifact_name: "Linux",
+            cores: 2,
+            install_dir: "/usr/local/"
+          }
+          - {
+            name: "Ubuntu/20.04/Static/X64/fsanitize",
+            os: ubuntu-20.04,
+            config: Debug,
+            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/bin/clang-12 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-12 -DCMAKE_C_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined' -DCMAKE_CXX_FLAGS='-fsanitize=address,pointer-compare,pointer-subtract,leak,undefined'",
             sudocmd: "sudo",
             artifact_name: "Linux",
             cores: 2,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             name: "Windows-MSVC/2019/Static/X86/Release",
             os: windows-2019,
             config: Release,
-            cmake_extra_args: -G "Visual Studio 16 2019" -A Win32,
+            cmake_extra_args: -G "Visual Studio 16 2019" -A Win32 -DCMAKE_CXX_FLAGS="/O2",
             sudocmd: "",
             artifact_name: "Windows x86",
             cores: 2,

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -852,21 +852,7 @@ namespace small::detail {
         /// \brief Find element in the small map
         iterator
         find(const key_type &k) {
-            if (!IsOrdered || data_.size() < 100) {
-                for (auto it = data_.begin(); it != data_.end(); ++it) {
-                    if (keys_equivalent(maybe_first(*it), k)) {
-                        return iterator(it);
-                    }
-                }
-                return end();
-            } else {
-                auto it = lower_bound(k);
-                if (keys_equivalent(maybe_first(*it), k)) {
-                    return it;
-                } else {
-                    return end();
-                }
-            }
+            return find<decltype(k)>(k);
         }
 
         /// \brief Find element in the small map
@@ -881,14 +867,14 @@ namespace small::detail {
         find(const K &x) {
             if (!IsOrdered || data_.size() < 100) {
                 for (auto it = data_.begin(); it != data_.end(); ++it) {
-                    if (it->first == x) {
+                    if (keys_equivalent(maybe_first(*it), x)) {
                         return iterator(it);
                     }
                 }
                 return end();
             } else {
                 auto it = lower_bound(x);
-                if (it->first == x) {
+                if (it != end() && keys_equivalent(maybe_first(*it), x)) {
                     return it;
                 } else {
                     return end();

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -1004,7 +1004,7 @@ namespace small::detail {
             return const_cast<associative_vector *>(this)->equal_range(x);
         }
 
-    private /* element access */:
+    private /* element lookup */:
         /// \brief Iterator to first element not less than key
         /// This will only work properly for ordered containers
         template <typename K>
@@ -1014,8 +1014,8 @@ namespace small::detail {
             const_iterator last,
             const K &x) {
             return iterator(std::lower_bound(
-                maybe_base(begin() + (first - cbegin())),
-                maybe_base(begin() + (last - cbegin())),
+                maybe_base(unconst(first)),
+                maybe_base(unconst(last)),
                 x,
                 [this](const auto &p, const auto &v) {
                 return comp_(maybe_first(p), v);
@@ -1043,8 +1043,8 @@ namespace small::detail {
             const_iterator last,
             const K &x) {
             return iterator(std::upper_bound(
-                maybe_base(begin() + (first - cbegin())),
-                maybe_base(begin() + (last - cbegin())),
+                maybe_base(unconst(first)),
+                maybe_base(unconst(last)),
                 x,
                 [this](const auto &v, const auto &p) {
                 return comp_(v, maybe_first(p));
@@ -1063,6 +1063,7 @@ namespace small::detail {
                 ->upper_bound_partial(begin, end, x);
         }
 
+    private /* element access */:
         /// \brief Logic to access a mapped_type
         template <bool create_if_not_found, class K>
         constexpr mapped_type &
@@ -1105,6 +1106,7 @@ namespace small::detail {
             }
         }
 
+    private /* helpers */:
         /// \brief Check if 2 keys are equivalent
         template <class K1, class K2>
         std::enable_if_t<
@@ -1134,6 +1136,11 @@ namespace small::detail {
             } else {
                 return el;
             }
+        }
+
+        constexpr iterator
+        unconst(const_iterator it) {
+            return begin() + (it - cbegin());
         }
 
     private:

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -786,11 +786,22 @@ namespace small::detail {
         /// \brief Erase element at a position in small map
         size_type
         erase(const key_type &k) {
+            return erase<decltype(k)>(k);
+        }
+
+        /// \brief Erase element at a position in small map
+        template <typename K>
+        std::enable_if_t<
+            !std::is_convertible_v<K &&, iterator>
+                && !std::is_convertible_v<K &&, const_iterator>
+                && (is_comp_tr || std::is_same_v<K, key_type>),
+            size_type>
+        erase(K &&x) {
             if constexpr (IsMulti) {
-                return erase_if([this, &k](const value_type &v) {
-                    return keys_equivalent(maybe_first(v), k);
+                return erase_if([this, &x](const value_type &v) {
+                    return keys_equivalent(maybe_first(v), x);
                 });
-            } else if (auto it = find(k); it != end()) {
+            } else if (auto it = find(x); it != end()) {
                 erase(it);
                 return 1;
             }

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -897,14 +897,25 @@ namespace small::detail {
             return (const_cast<associative_vector *>(this))->find(x);
         }
 
-        /// \brief Count elements with a given key (0 or 1)
+        /// \brief Count elements with a given key
         template <typename K>
         std::enable_if_t<is_comp_tr || std::is_same_v<K, key_type>, size_type>
         count(const K &x) const {
-            return find(x) != end() ? 1 : 0;
+            if constexpr (!IsMulti) {
+                return find(x) != end() ? 1 : 0;
+            }
+
+            if constexpr (IsOrdered) {
+                auto [first, last] = equal_range(x);
+                return std::distance(first, last);
+            }
+
+            return std::count_if(begin(), end(), [this, &x](auto const &v) {
+                return keys_equivalent(maybe_first(v), x);
+            });
         }
 
-        /// \brief Count elements with a given key (0 or 1)
+        /// \brief Count elements with a given key
         size_type
         count(const key_type &k) const {
             return count<decltype(k)>(k);

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -800,6 +800,17 @@ namespace small::detail {
             return iterator(data_.erase(maybe_base(first), maybe_base(last)));
         }
 
+        /// \brief Erase elements that match the predicate
+        template <typename Pred>
+        size_type
+        erase_if(Pred p) {
+            auto const old_size = size();
+            data_.erase(
+                std::remove_if(data_.begin(), data_.end(), p),
+                data_.end());
+            return old_size - size();
+        }
+
         /// \brief Clear elements in the small map
         constexpr void
         clear() noexcept {
@@ -1273,6 +1284,13 @@ namespace small::detail {
         associative_vector<b1, b2, b3, V, C> &x,
         associative_vector<b1, b2, b3, V, C> &y) noexcept(noexcept(x.swap(y))) {
         x.swap(y);
+    }
+
+    /// \brief Erase elements that match the predicate
+    template <bool b1, bool b2, bool b3, class V, class C, class Pred>
+    typename associative_vector<b1, b2, b3, V, C>::size_type
+    erase_if(associative_vector<b1, b2, b3, V, C> &c, Pred p) {
+        return c.erase_if(p);
     }
 } // namespace small::detail
 

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -799,6 +799,7 @@ namespace small::detail {
         erase(K &&x) {
             if constexpr (IsMulti && !IsOrdered) {
                 return erase_if([this, &x](const value_type &v) {
+                    (void)this; // clang warns -Wunused-lambda-capture otherwise
                     return keys_equivalent(maybe_first(v), x);
                 });
             }
@@ -806,6 +807,7 @@ namespace small::detail {
             auto const first = find(x);
             auto const last = std::
                 find_if(first, end(), [this, &x](auto const &v) {
+                (void)this; // clang warns -Wunused-lambda-capture otherwise
                 return !keys_equivalent(maybe_first(v), x);
             });
             auto const ret = std::distance(first, last);
@@ -911,6 +913,7 @@ namespace small::detail {
             }
 
             return std::count_if(begin(), end(), [this, &x](auto const &v) {
+                (void)this; // clang warns -Wunused-lambda-capture otherwise
                 return keys_equivalent(maybe_first(v), x);
             });
         }

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -902,7 +902,7 @@ namespace small::detail {
         std::enable_if_t<is_comp_tr || std::is_same_v<K, key_type>, size_type>
         count(const K &x) const {
             if constexpr (!IsMulti) {
-                return find(x) != end() ? 1 : 0;
+                return contains(x) ? 1 : 0;
             }
 
             if constexpr (IsOrdered) {
@@ -925,7 +925,7 @@ namespace small::detail {
         template <typename K>
         std::enable_if_t<is_comp_tr || std::is_same_v<K, key_type>, bool>
         contains(const K &x) const {
-            return count(x) > 0;
+            return find(x) != end();
         }
 
         /// \brief Check if elements with a given key exists

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -786,8 +786,11 @@ namespace small::detail {
         /// \brief Erase element at a position in small map
         size_type
         erase(const key_type &k) {
-            auto it = find(k);
-            if (it != end()) {
+            if constexpr (IsMulti) {
+                return erase_if([this, &k](const value_type &v) {
+                    return keys_equivalent(maybe_first(v), k);
+                });
+            } else if (auto it = find(k); it != end()) {
                 erase(it);
                 return 1;
             }

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -878,7 +878,14 @@ namespace small::detail {
         template <typename K>
         std::enable_if_t<is_comp_tr || std::is_same_v<K, key_type>, iterator>
         find(const K &x) {
-            if (!IsOrdered || size() < 100) {
+            if constexpr (!IsOrdered) {
+                // blame MSVC warning C4127 for this travesty of code >:(
+                for (auto it = begin(), last = end(); it != last; ++it) {
+                    if (keys_equivalent(maybe_first(*it), x)) {
+                        return it;
+                    }
+                }
+            } else if (size() < 100) {
                 for (auto it = begin(), last = end(); it != last; ++it) {
                     if (keys_equivalent(maybe_first(*it), x)) {
                         return it;

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -1,4 +1,5 @@
 //
+// Copyright (c) 2024 Yat Ho (lagoho7@gmail.com)
 // Copyright (c) 2021 alandefreitas (alandefreitas@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0.

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -912,17 +912,15 @@ namespace small::detail {
         count(const K &x) const {
             if constexpr (!IsMulti) {
                 return contains(x) ? 1 : 0;
-            }
-
-            if constexpr (IsOrdered) {
+            } else if constexpr (IsOrdered) {
                 auto [first, last] = equal_range(x);
                 return std::distance(first, last);
+            } else {
+                return std::count_if(begin(), end(), [this, &x](auto const &v) {
+                    (void) this; // clang warns -Wunused-lambda-capture otherwise
+                    return keys_equivalent(maybe_first(v), x);
+                });
             }
-
-            return std::count_if(begin(), end(), [this, &x](auto const &v) {
-                (void)this; // clang warns -Wunused-lambda-capture otherwise
-                return keys_equivalent(maybe_first(v), x);
-            });
         }
 
         /// \brief Count elements with a given key

--- a/include/small/detail/container/associative_vector.hpp
+++ b/include/small/detail/container/associative_vector.hpp
@@ -100,7 +100,7 @@ namespace small::detail {
         struct is_transparent<Func, std::void_t<typename Func::is_transparent>>
             : std::true_type
         {};
-        template <typename Func>
+        template <class Func>
         static auto constexpr is_transparent_v = is_transparent<Func>::value;
         static auto constexpr is_comp_tr = is_transparent_v<Compare>;
 
@@ -865,21 +865,18 @@ namespace small::detail {
         template <typename K>
         std::enable_if_t<is_comp_tr || std::is_same_v<K, key_type>, iterator>
         find(const K &x) {
-            if (!IsOrdered || data_.size() < 100) {
-                for (auto it = data_.begin(); it != data_.end(); ++it) {
+            if (!IsOrdered || size() < 100) {
+                for (auto it = begin(), last = end(); it != last; ++it) {
                     if (keys_equivalent(maybe_first(*it), x)) {
-                        return iterator(it);
+                        return it;
                     }
                 }
-                return end();
-            } else {
-                auto it = lower_bound(x);
-                if (it != end() && keys_equivalent(maybe_first(*it), x)) {
-                    return it;
-                } else {
-                    return end();
-                }
+            } else if (auto it = lower_bound(x);
+                       it != end() && keys_equivalent(maybe_first(*it), x))
+            {
+                return it;
             }
+            return end();
         }
 
         /// \brief Find element in the small map

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -561,6 +561,22 @@ TEST_CASE("Small Map") {
                 { 7, 7 }
         }));
 
+        it = a.try_emplace(a.upper_bound(10), 10, 10);
+        REQUIRE(it == std::prev(a.end()));
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 6, 6 },
+                { 7, 7 },
+                { 10, 10 }
+        }));REQUIRE(a.erase(10) == 1);
+
         std::tie(it, ok) = a.insert_or_assign(1, 8);
         REQUIRE_FALSE(ok);
         REQUIRE(it == a.begin());
@@ -592,6 +608,40 @@ TEST_CASE("Small Map") {
                 { 3, 3 },
                 { 6, 6 },
                 { 7, 7 }
+        }));
+
+        it = a.insert_or_assign(a.upper_bound(10), 10, 10);
+        REQUIRE(it == std::prev(a.end()));
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 8 },
+                { 2, 2 },
+                { 3, 3 },
+                { 6, 6 },
+                { 7, 7 },
+                { 10, 10 }
+        }));
+
+        it = a.insert_or_assign(a.upper_bound(10), 10, 10);
+        REQUIRE(it == std::prev(a.end()));
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 8 },
+                { 2, 2 },
+                { 3, 3 },
+                { 6, 6 },
+                { 7, 7 },
+                { 10, 10 }
         }));
 
         a.clear();

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -547,6 +547,27 @@ TEST_CASE("Small Map") {
         }
     }
 
+    SECTION("Find in small map") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+
+        REQUIRE(a.find(1) == a.begin());
+        REQUIRE(a.find(4) == a.end());
+    }
+
+    SECTION("Find in big map") {
+        small_map_type a = {};
+        for (int i = 0; i < 1000; ++i) {
+            a[i] = i;
+        }
+
+        REQUIRE(a.find(0) == a.begin());
+        REQUIRE(a.find(1000) == a.end());
+    }
+
     SECTION("Relational Operators") {
         small_map_type a = {
             { 1, 1 },

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -342,6 +342,7 @@ TEST_CASE("Small Map") {
                 { 3, 3 },
                 { 4, 4 }
         }));
+        REQUIRE(a.count(4) == 1);
 
         // NOLINTNEXTLINE(performance-move-const-arg)
         auto p = std::make_pair(5, 5);
@@ -360,6 +361,7 @@ TEST_CASE("Small Map") {
                 { 4, 4 },
                 { 5, 5 }
         }));
+        REQUIRE(a.count(5) == 1);
 
         REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
@@ -374,6 +376,7 @@ TEST_CASE("Small Map") {
                 { 3, 3 },
                 { 4, 4 }
         }));
+        REQUIRE(a.count(5) == 0);
 
         a.emplace(5, 5);
         REQUIRE(a.back().first == 5);
@@ -390,6 +393,7 @@ TEST_CASE("Small Map") {
                 { 4, 4 },
                 { 5, 5 }
         }));
+        REQUIRE(a.count(5) == 1);
 
         a.erase(std::prev(a.end()));
         REQUIRE(a.size() == 4);
@@ -421,6 +425,7 @@ TEST_CASE("Small Map") {
                 {  4,  4 },
                 { 10, 10 }
         }));
+        REQUIRE(a.count(10) == 1);
 
         REQUIRE(a.erase(10) == 1);
         REQUIRE(a.erase(4) == 1);
@@ -435,6 +440,7 @@ TEST_CASE("Small Map") {
                 { 2, 2 },
                 { 3, 3 }
         }));
+        REQUIRE(a.count(10) == 0);
 
         std::initializer_list<std::pair<const int, int>> src = {
             { 6, 6 },
@@ -1535,6 +1541,7 @@ TEST_CASE("Small Multi Map") {
                 { 3, 3 },
                 { 4, 4 }
         }));
+        REQUIRE(a.count(4) == 1);
 
         // NOLINTNEXTLINE(performance-move-const-arg)
         auto p = std::make_pair(5, 5);
@@ -1553,6 +1560,7 @@ TEST_CASE("Small Multi Map") {
                 { 4, 4 },
                 { 5, 5 }
         }));
+        REQUIRE(a.count(5) == 1);
 
         REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
@@ -1567,6 +1575,7 @@ TEST_CASE("Small Multi Map") {
                 { 3, 3 },
                 { 4, 4 }
         }));
+        REQUIRE(a.count(5) == 0);
 
         a.emplace(5, 5);
         REQUIRE(a.back().first == 5);
@@ -1583,6 +1592,7 @@ TEST_CASE("Small Multi Map") {
                 { 4, 4 },
                 { 5, 5 }
         }));
+        REQUIRE(a.count(5) == 1);
 
         a.erase(std::prev(a.end()));
         REQUIRE(a.size() == 4);
@@ -1614,6 +1624,7 @@ TEST_CASE("Small Multi Map") {
                 {  4,  4 },
                 { 10, 10 }
         }));
+        REQUIRE(a.count(10) == 1);
 
         REQUIRE(a.erase(10) == 1);
         REQUIRE(a.erase(4) == 1);
@@ -1628,6 +1639,7 @@ TEST_CASE("Small Multi Map") {
                 { 2, 2 },
                 { 3, 3 }
         }));
+        REQUIRE(a.count(10) == 0);
 
         std::initializer_list<std::pair<const int, int>> src = {
             { 6, 6 },
@@ -1687,6 +1699,7 @@ TEST_CASE("Small Multi Map") {
                 { 7, 7 },
                 { 7, 8 }
         }));
+        REQUIRE(a.count(7) == 2);
 
         it = a.erase(a.begin() + 1);
         REQUIRE(it == a.begin() + 1);
@@ -1731,6 +1744,7 @@ TEST_CASE("Small Multi Map") {
                 { 1, 1 },
                 { 6, 6 }
         }));
+        REQUIRE(a.count(7) == 0);
 
         a.clear();
         // NOLINTNEXTLINE(readability-container-size-empty)

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Small Map") {
     using namespace small;
 
     auto equal_il =
-        [](const auto &sm_map,
+        [](const auto& sm_map,
            std::initializer_list<std::pair<const int, int>> il) -> bool {
         return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
     };
@@ -570,12 +570,13 @@ TEST_CASE("Small Map") {
         REQUIRE(equal_il(
             a,
             {
-                { 1, 1 },
-                { 2, 2 },
-                { 6, 6 },
-                { 7, 7 },
+                {  1,  1 },
+                {  2,  2 },
+                {  6,  6 },
+                {  7,  7 },
                 { 10, 10 }
-        }));REQUIRE(a.erase(10) == 1);
+        }));
+        REQUIRE(a.erase(10) == 1);
 
         std::tie(it, ok) = a.insert_or_assign(1, 8);
         REQUIRE_FALSE(ok);
@@ -619,11 +620,11 @@ TEST_CASE("Small Map") {
         REQUIRE(equal_il(
             a,
             {
-                { 1, 8 },
-                { 2, 2 },
-                { 3, 3 },
-                { 6, 6 },
-                { 7, 7 },
+                {  1,  8 },
+                {  2,  2 },
+                {  3,  3 },
+                {  6,  6 },
+                {  7,  7 },
                 { 10, 10 }
         }));
 
@@ -636,11 +637,11 @@ TEST_CASE("Small Map") {
         REQUIRE(equal_il(
             a,
             {
-                { 1, 8 },
-                { 2, 2 },
-                { 3, 3 },
-                { 6, 6 },
-                { 7, 7 },
+                {  1,  8 },
+                {  2,  2 },
+                {  3,  3 },
+                {  6,  6 },
+                {  7,  7 },
                 { 10, 10 }
         }));
 
@@ -721,7 +722,7 @@ TEST_CASE("Small Map") {
         try {
             a.at(4);
         }
-        catch (std::exception &e) {
+        catch (std::exception& e) {
             REQUIRE(
                 e.what()
                 == std::string_view("at(): cannot find element in vector map"));
@@ -774,7 +775,7 @@ TEST_CASE("Max Size Map") {
     using namespace small;
 
     auto equal_il =
-        [](const auto &sm_map,
+        [](const auto& sm_map,
            std::initializer_list<std::pair<const int, int>> il) -> bool {
         return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
     };
@@ -1260,7 +1261,7 @@ TEST_CASE("Max Size Map") {
         try {
             a.at(4);
         }
-        catch (std::exception &e) {
+        catch (std::exception& e) {
             REQUIRE(
                 e.what()
                 == std::string_view("at(): cannot find element in vector map"));
@@ -1292,7 +1293,7 @@ TEST_CASE("Small Multi Map") {
     using namespace small;
 
     auto equal_il =
-        [](const auto &sm_map,
+        [](const auto& sm_map,
            std::initializer_list<std::pair<const int, int>> il) -> bool {
         return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
     };
@@ -1814,7 +1815,1286 @@ TEST_CASE("Small Multi Map") {
         try {
             a.at(4);
         }
-        catch (std::exception &e) {
+        catch (std::exception& e) {
+            REQUIRE(
+                e.what()
+                == std::string_view("at(): cannot find element in vector map"));
+        }
+    }
+
+    SECTION("Relational Operators") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        small_map_type b = {
+            { 2, 2 },
+            { 4, 4 },
+            { 5, 5 }
+        };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}
+
+TEST_CASE("Small Unordered Map") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto& sm_map,
+           std::initializer_list<std::pair<const int, int>> il) -> bool {
+        return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
+    };
+
+    using small_map_type = unordered_map<int, int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_map_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<std::pair<int, int>> alloc;
+            std::vector<std::pair<int, int>> dv = {
+                { 4, 5 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            small_map_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 3);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(
+                d,
+                {
+                    { 4, 5 },
+                    { 5, 6 },
+                    { 7, 8 }
+            }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_map_type e = {
+                { 1, 2 },
+                { 2, 3 }
+            };
+            REQUIRE(e.size() == 2);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(
+                e,
+                {
+                    { 1, 2 },
+                    { 2, 3 }
+            }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 6, 7 },
+                { 5, 4 },
+                { 4, 5 }
+            };
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 7 },
+                    { 5, 4 },
+                    { 4, 5 }
+            }));
+        }
+
+        SECTION("From another flat map") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 6, 7 },
+                { 5, 6 },
+                { 4, 5 }
+            };
+
+            small_map_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 3);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 7 },
+                    { 5, 6 },
+                    { 4, 5 }
+            }));
+        }
+
+        SECTION("From iterators") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            std::vector<std::pair<int, int>> v = {
+                { 6, 4 },
+                { 5, 6 },
+                { 4, 6 }
+            };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 4 },
+                    { 5, 6 },
+                    { 4, 6 }
+            }));
+        }
+
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a.assign({
+                { 6, 5 },
+                { 5, 2 },
+                { 4, 2 }
+            });
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 5 },
+                    { 5, 2 },
+                    { 4, 2 }
+            }));
+        }
+
+        SECTION("Swap") {
+            small_map_type a = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            small_map_type b = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            std::initializer_list<std::pair<const int, int>> ar = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            std::initializer_list<std::pair<const int, int>> br = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 4);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_map_type a = {
+            { 1, 2 },
+            { 2, 3 },
+            { 3, 3 }
+        };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin()->first == 1);
+        REQUIRE(std::prev(a.end())->first == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin()->first == 1);
+        REQUIRE(std::prev(a.cend())->first == 3);
+
+        REQUIRE(a.rbegin()->first == 3);
+        REQUIRE(std::prev(a.rend())->first == 1);
+
+        REQUIRE(a.crbegin()->first == 3);
+        REQUIRE(std::prev(a.crend())->first == 1);
+    }
+
+    SECTION("Capacity") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        REQUIRE(a[1] == 1);
+        REQUIRE(a[2] == 2);
+        REQUIRE(a[3] == 3);
+        REQUIRE(a.at(1) == 1);
+        REQUIRE(a.at(2) == 2);
+        REQUIRE(a.at(3) == 3);
+        REQUIRE_THROWS(a.at(4));
+        REQUIRE_THROWS(a.at(5));
+        REQUIRE(a.front().first == 1);
+        REQUIRE(a.back().first == 3);
+        REQUIRE(a.data()->first == 1);
+        REQUIRE((a.data() + 1)->first == 2);
+        REQUIRE((a.data() + 2)->first == 3);
+        REQUIRE((a.data() + a.size() - 1)->first == 3);
+        REQUIRE((a.data() + a.size() - 2)->first == 2);
+        REQUIRE((a.data() + a.size() - 3)->first == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back().first == 4);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+        REQUIRE(a.count(4) == 1);
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        auto p = std::make_pair(5, 5);
+        a.insert(std::move(p));
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+        REQUIRE(a.count(5) == 1);
+
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+        REQUIRE(a.count(5) == 0);
+
+        a.emplace(5, 5);
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+        REQUIRE(a.count(5) == 1);
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+
+        auto it = a.emplace_hint(a.begin() + 3, 10, 10);
+        REQUIRE(it->first == (a.begin() + 3)->first);
+        REQUIRE(a.back().first == 4);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  1 },
+                {  2,  2 },
+                {  3,  3 },
+                { 10, 10 },
+                {  4,  4 }
+        }));
+        REQUIRE(a.count(10) == 1);
+
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 }
+        }));
+        REQUIRE(a.count(10) == 0);
+
+        std::initializer_list<std::pair<const int, int>> src = {
+            { 6, 6 },
+            { 5, 5 },
+            { 7, 7 }
+        };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 6, 6 },
+                { 5, 5 },
+                { 7, 7 }
+        }));
+
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 7, 7 }
+        }));
+
+        a.insert({
+            { 4, 4 },
+            { 5, 5 },
+            { 6, 6 }
+        });
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 7, 7 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 }
+        }));
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 7, 7 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 }
+        }));
+
+        it = a.erase(a.begin() + 1, a.begin() + 3);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 5, 5 },
+                { 6, 6 }
+        }));
+
+        bool ok = false;
+        std::tie(it, ok) = a.try_emplace(1, 8);
+        REQUIRE_FALSE(ok);
+        REQUIRE(it == a.begin());
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 5, 5 },
+                { 6, 6 }
+        }));
+
+        std::tie(it, ok) = a.try_emplace(2, 2);
+        REQUIRE(ok);
+        REQUIRE(it == std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 5, 5 },
+                { 6, 6 },
+                { 2, 2 }
+        }));
+
+        it = a.try_emplace(a.begin() + 2, 10, 10);
+        REQUIRE(it == a.begin() + 2);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  1 },
+                {  5,  5 },
+                { 10, 10 },
+                {  6,  6 },
+                {  2,  2 }
+        }));
+        REQUIRE(a.erase(10) == 1);
+
+        std::tie(it, ok) = a.insert_or_assign(1, 8);
+        REQUIRE_FALSE(ok);
+        REQUIRE(it == a.begin());
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 8 },
+                { 5, 5 },
+                { 6, 6 },
+                { 2, 2 }
+        }));
+
+        std::tie(it, ok) = a.insert_or_assign(3, 3);
+        REQUIRE(ok);
+        REQUIRE(it == std::prev(a.end()));
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 8 },
+                { 5, 5 },
+                { 6, 6 },
+                { 2, 2 },
+                { 3, 3 }
+        }));
+
+        it = a.insert_or_assign(a.begin() + 2, 10, 10);
+        REQUIRE(it == a.begin() + 2);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  8 },
+                {  5,  5 },
+                { 10, 10 },
+                {  6,  6 },
+                {  2,  2 },
+                {  3,  3 }
+        }));
+
+        it = a.insert_or_assign(a.begin() + 3, 10, 12);
+        REQUIRE(it == a.begin() + 2);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  8 },
+                {  5,  5 },
+                { 10, 12 },
+                {  6,  6 },
+                {  2,  2 },
+                {  3,  3 }
+        }));
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("try_emplace() has no effect if didn't insert") {
+        struct A
+        {
+            A() = default;
+            A(A&& a) noexcept {
+                *this = std::move(a);
+            }
+            A(A const& a) {
+                *this = a;
+            }
+            A&
+            operator=(A&& a) noexcept {
+                moved = a.moved;
+                copied = a.copied;
+                a.moved = true;
+                return *this;
+            }
+            A&
+            operator=(A const& a) {
+                moved = a.moved;
+                copied = a.copied;
+                a.copied = true;
+                return *this;
+            }
+
+            mutable bool moved = false;
+            mutable bool copied = false;
+        };
+        small::map<int, A> a = {};
+
+        A obj = {};
+        a.try_emplace(1, obj);
+        REQUIRE(a.size() == 1);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE_FALSE(obj.moved);
+        REQUIRE(obj.copied);
+
+        obj = {};
+        a.try_emplace(2, std::move(obj));
+        REQUIRE(a.size() == 2);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(obj.moved);
+        REQUIRE_FALSE(obj.copied);
+
+        obj = {};
+        a.try_emplace(1, obj);
+        REQUIRE(a.size() == 2);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE_FALSE(obj.moved);
+        REQUIRE_FALSE(obj.copied);
+
+        obj = {};
+        a.try_emplace(2, std::move(obj));
+        REQUIRE(a.size() == 2);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE_FALSE(obj.moved);
+        REQUIRE_FALSE(obj.copied);
+    }
+
+    SECTION("Element access errors") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        try {
+            a.at(4);
+        }
+        catch (std::exception& e) {
+            REQUIRE(
+                e.what()
+                == std::string_view("at(): cannot find element in vector map"));
+        }
+    }
+
+    SECTION("Find in small map") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+
+        REQUIRE(a.find(1) == a.begin());
+        REQUIRE(a.find(4) == a.end());
+    }
+
+    SECTION("Find in big map") {
+        small_map_type a = {};
+        for (int i = 0; i < 1000; ++i) {
+            a[i] = i;
+        }
+
+        REQUIRE(a.find(0) == a.begin());
+        REQUIRE(a.find(1000) == a.end());
+    }
+
+    SECTION("Relational Operators") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        small_map_type b = {
+            { 2, 2 },
+            { 4, 4 },
+            { 5, 5 }
+        };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}
+
+TEST_CASE("Small Unordered Multi Map") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto& sm_map,
+           std::initializer_list<std::pair<const int, int>> il) -> bool {
+        return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
+    };
+
+    using small_map_type = unordered_multimap<int, int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_map_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<std::pair<int, int>> alloc;
+            std::vector<std::pair<int, int>> dv = {
+                { 4, 5 },
+                { 5, 6 },
+                { 7, 8 },
+                { 7, 9 }
+            };
+            small_map_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 4);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(
+                d,
+                {
+                    { 4, 5 },
+                    { 5, 6 },
+                    { 7, 8 },
+                    { 7, 9 }
+            }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_map_type e = {
+                { 1, 2 },
+                { 2, 3 },
+                { 2, 5 }
+            };
+            REQUIRE(e.size() == 3);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(
+                e,
+                {
+                    { 1, 2 },
+                    { 2, 3 },
+                    { 2, 5 }
+            }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 4, 5 },
+                { 4, 8 },
+                { 5, 4 },
+                { 6, 7 }
+            };
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 4, 5 },
+                    { 4, 8 },
+                    { 5, 4 },
+                    { 6, 7 }
+            }));
+        }
+
+        SECTION("From another flat map") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 6, 7 },
+                { 5, 6 },
+                { 5, 4 },
+                { 4, 5 }
+            };
+
+            small_map_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 4);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 7 },
+                    { 5, 6 },
+                    { 5, 4 },
+                    { 4, 5 }
+            }));
+        }
+
+        SECTION("From iterators") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            std::vector<std::pair<int, int>> v = {
+                { 6, 4 },
+                { 5, 6 },
+                { 4, 6 },
+                { 4, 5 }
+            };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 4 },
+                    { 5, 6 },
+                    { 4, 6 },
+                    { 4, 5 }
+            }));
+        }
+
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a.assign({
+                { 6, 5 },
+                { 5, 2 },
+                { 4, 2 },
+                { 4, 3 }
+            });
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 6, 5 },
+                    { 5, 2 },
+                    { 4, 2 },
+                    { 4, 3 }
+            }));
+        }
+
+        SECTION("Swap") {
+            small_map_type a = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            small_map_type b = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            std::initializer_list<std::pair<const int, int>> ar = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            std::initializer_list<std::pair<const int, int>> br = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 4);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_map_type a = {
+            { 1, 2 },
+            { 2, 3 },
+            { 3, 3 },
+            { 3, 4 }
+        };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin()->first == 1);
+        REQUIRE(std::prev(a.end())->first == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin()->first == 1);
+        REQUIRE(std::prev(a.cend())->first == 3);
+
+        REQUIRE(a.rbegin()->first == 3);
+        REQUIRE(std::prev(a.rend())->first == 1);
+
+        REQUIRE(a.crbegin()->first == 3);
+        REQUIRE(std::prev(a.crend())->first == 1);
+    }
+
+    SECTION("Capacity") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 },
+            { 4, 5 }
+        };
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_map_type a = {
+            { 1, 1 },
+            { 1, 2 },
+            { 3, 3 }
+        };
+        REQUIRE(a.front().first == 1);
+        REQUIRE(a.back().first == 3);
+        REQUIRE(a.data()->first == 1);
+        REQUIRE((a.data() + 1)->first == 1);
+        REQUIRE((a.data() + 2)->first == 3);
+        REQUIRE((a.data() + a.size() - 1)->first == 3);
+        REQUIRE((a.data() + a.size() - 2)->first == 1);
+        REQUIRE((a.data() + a.size() - 3)->first == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back().first == 4);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+        REQUIRE(a.count(4) == 1);
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        auto p = std::make_pair(5, 5);
+        a.insert(std::move(p));
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+        REQUIRE(a.count(5) == 1);
+
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+        REQUIRE(a.count(5) == 0);
+
+        a.emplace(5, 5);
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+        REQUIRE(a.count(5) == 1);
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+
+        auto it = a.emplace_hint(a.begin() + 2, 10, 10);
+        REQUIRE(it->first == (a.begin() + 2)->first);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  1 },
+                {  2,  2 },
+                { 10, 10 },
+                {  3,  3 },
+                {  4,  4 }
+        }));
+        REQUIRE(a.count(10) == 1);
+
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 }
+        }));
+        REQUIRE(a.count(10) == 0);
+
+        std::initializer_list<std::pair<const int, int>> src = {
+            { 6, 6 },
+            { 5, 5 },
+            { 7, 7 }
+        };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 6, 6 },
+                { 5, 5 },
+                { 7, 7 }
+        }));
+
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 7, 7 }
+        }));
+
+        a.insert({
+            { 4, 4 },
+            { 5, 5 },
+            { 6, 6 },
+            { 7, 8 }
+        });
+        REQUIRE(a.size() == 7);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 7);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 7, 7 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 },
+                { 7, 8 }
+        }));
+        REQUIRE(a.count(7) == 2);
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 7, 7 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 },
+                { 7, 8 }
+        }));
+
+        it = a.erase(a.begin() + 2, a.begin() + 4);
+        REQUIRE(it == a.begin() + 2);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 7, 7 },
+                { 6, 6 },
+                { 7, 8 }
+        }));
+
+        REQUIRE(a.erase(7) == 2);
+        REQUIRE(a.size() == 2);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 6, 6 }
+        }));
+        REQUIRE(a.count(7) == 0);
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("Element access errors") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        try {
+            a.at(4);
+        }
+        catch (std::exception& e) {
             REQUIRE(
                 e.what()
                 == std::string_view("at(): cannot find element in vector map"));

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -361,7 +361,7 @@ TEST_CASE("Small Map") {
                 { 5, 5 }
         }));
 
-        a.erase(5);
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -422,8 +422,8 @@ TEST_CASE("Small Map") {
                 { 10, 10 }
         }));
 
-        a.erase(10);
-        a.erase(4);
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -457,9 +457,10 @@ TEST_CASE("Small Map") {
                 { 7, 7 }
         }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() >= 3);
@@ -1029,7 +1030,7 @@ TEST_CASE("Max Size Map") {
                 { 5, 5 }
         }));
 
-        a.erase(5);
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -1090,8 +1091,8 @@ TEST_CASE("Max Size Map") {
                 { 10, 10 }
         }));
 
-        a.erase(10);
-        a.erase(4);
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -1123,9 +1124,10 @@ TEST_CASE("Max Size Map") {
                 { 6, 6 }
         }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(7) == 0);
         REQUIRE(a.size() == 2);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -1261,17 +1263,19 @@ TEST_CASE("Small Multi Map") {
             std::vector<std::pair<int, int>> dv = {
                 { 4, 5 },
                 { 5, 6 },
-                { 7, 8 }
+                { 7, 8 },
+                { 7, 9 }
             };
             small_map_type d(dv.begin(), dv.end(), alloc);
-            REQUIRE(d.size() == 3);
+            REQUIRE(d.size() == 4);
             REQUIRE_FALSE(d.empty());
             REQUIRE(equal_il(
                 d,
                 {
                     { 4, 5 },
                     { 5, 6 },
-                    { 7, 8 }
+                    { 7, 8 },
+                    { 7, 9 }
             }));
             REQUIRE(d.get_allocator() == alloc);
         }
@@ -1279,15 +1283,17 @@ TEST_CASE("Small Multi Map") {
         SECTION("From initializer list") {
             small_map_type e = {
                 { 1, 2 },
-                { 2, 3 }
+                { 2, 3 },
+                { 2, 5 }
             };
-            REQUIRE(e.size() == 2);
+            REQUIRE(e.size() == 3);
             REQUIRE_FALSE(e.empty());
             REQUIRE(equal_il(
                 e,
                 {
                     { 1, 2 },
-                    { 2, 3 }
+                    { 2, 3 },
+                    { 2, 5 }
             }));
         }
     }
@@ -1299,14 +1305,16 @@ TEST_CASE("Small Multi Map") {
             a = {
                 { 6, 7 },
                 { 5, 4 },
-                { 4, 5 }
+                { 4, 5 },
+                { 4, 8 }
             };
-            REQUIRE(a.size() == 3);
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
             REQUIRE(equal_il(
                 a,
                 {
                     { 4, 5 },
+                    { 4, 8 },
                     { 5, 4 },
                     { 6, 7 }
             }));
@@ -1318,13 +1326,14 @@ TEST_CASE("Small Multi Map") {
             a = {
                 { 6, 7 },
                 { 5, 6 },
+                { 5, 4 },
                 { 4, 5 }
             };
 
             small_map_type b;
             REQUIRE(b.empty());
             b = a;
-            REQUIRE(b.size() == 3);
+            REQUIRE(b.size() == 4);
             REQUIRE_FALSE(b.empty());
             REQUIRE(a == b);
             REQUIRE(equal_il(
@@ -1332,6 +1341,7 @@ TEST_CASE("Small Multi Map") {
                 {
                     { 4, 5 },
                     { 5, 6 },
+                    { 5, 4 },
                     { 6, 7 }
             }));
         }
@@ -1342,15 +1352,17 @@ TEST_CASE("Small Multi Map") {
             std::vector<std::pair<int, int>> v = {
                 { 6, 4 },
                 { 5, 6 },
-                { 4, 6 }
+                { 4, 6 },
+                { 4, 5 }
             };
             a.assign(v.begin(), v.end());
-            REQUIRE(a.size() == 3);
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
             REQUIRE(equal_il(
                 a,
                 {
                     { 4, 6 },
+                    { 4, 5 },
                     { 5, 6 },
                     { 6, 4 }
             }));
@@ -1362,14 +1374,16 @@ TEST_CASE("Small Multi Map") {
             a.assign({
                 { 6, 5 },
                 { 5, 2 },
-                { 4, 2 }
+                { 4, 2 },
+                { 4, 3 }
             });
-            REQUIRE(a.size() == 3);
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
             REQUIRE(equal_il(
                 a,
                 {
                     { 4, 2 },
+                    { 4, 3 },
                     { 5, 2 },
                     { 6, 5 }
             }));
@@ -1431,7 +1445,8 @@ TEST_CASE("Small Multi Map") {
         small_map_type a = {
             { 1, 2 },
             { 2, 3 },
-            { 3, 3 }
+            { 3, 3 },
+            { 3, 4 }
         };
 
         REQUIRE(a.begin().operator->() == a.data());
@@ -1457,27 +1472,28 @@ TEST_CASE("Small Multi Map") {
         small_map_type a = {
             { 1, 1 },
             { 2, 2 },
-            { 3, 3 }
+            { 3, 3 },
+            { 4, 5 }
         };
-        REQUIRE(a.size() == 3);
+        REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(a.capacity() == 5);
 
         a.reserve(10);
-        REQUIRE(a.size() == 3);
+        REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(a.capacity() >= 10);
 
         a.shrink_to_fit();
-        REQUIRE(a.size() == 3);
+        REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(a.capacity() == 5);
 
         a.shrink_to_fit();
-        REQUIRE(a.size() == 3);
+        REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
@@ -1486,24 +1502,16 @@ TEST_CASE("Small Multi Map") {
     SECTION("Element access") {
         small_map_type a = {
             { 1, 1 },
-            { 2, 2 },
+            { 1, 2 },
             { 3, 3 }
         };
-        REQUIRE(a[1] == 1);
-        REQUIRE(a[2] == 2);
-        REQUIRE(a[3] == 3);
-        REQUIRE(a.at(1) == 1);
-        REQUIRE(a.at(2) == 2);
-        REQUIRE(a.at(3) == 3);
-        REQUIRE_THROWS(a.at(4));
-        REQUIRE_THROWS(a.at(5));
         REQUIRE(a.front().first == 1);
         REQUIRE(a.back().first == 3);
         REQUIRE(a.data()->first == 1);
-        REQUIRE((a.data() + 1)->first == 2);
+        REQUIRE((a.data() + 1)->first == 1);
         REQUIRE((a.data() + 2)->first == 3);
         REQUIRE((a.data() + a.size() - 1)->first == 3);
-        REQUIRE((a.data() + a.size() - 2)->first == 2);
+        REQUIRE((a.data() + a.size() - 2)->first == 1);
         REQUIRE((a.data() + a.size() - 3)->first == 1);
     }
 
@@ -1546,7 +1554,7 @@ TEST_CASE("Small Multi Map") {
                 { 5, 5 }
         }));
 
-        a.erase(5);
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -1607,8 +1615,8 @@ TEST_CASE("Small Multi Map") {
                 { 10, 10 }
         }));
 
-        a.erase(10);
-        a.erase(4);
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -1642,9 +1650,10 @@ TEST_CASE("Small Multi Map") {
                 { 7, 7 }
         }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() >= 3);
@@ -1660,11 +1669,12 @@ TEST_CASE("Small Multi Map") {
         a.insert({
             { 4, 4 },
             { 5, 5 },
-            { 6, 6 }
+            { 6, 6 },
+            { 7, 8 }
         });
-        REQUIRE(a.size() == 6);
+        REQUIRE(a.size() == 7);
         REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() >= 6);
+        REQUIRE(a.capacity() >= 7);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(
             a,
@@ -1674,14 +1684,15 @@ TEST_CASE("Small Multi Map") {
                 { 4, 4 },
                 { 5, 5 },
                 { 6, 6 },
-                { 7, 7 }
+                { 7, 7 },
+                { 7, 8 }
         }));
 
         it = a.erase(a.begin() + 1);
         REQUIRE(it == a.begin() + 1);
-        REQUIRE(a.size() == 5);
+        REQUIRE(a.size() == 6);
         REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.capacity() >= 6);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(
             a,
@@ -1690,12 +1701,13 @@ TEST_CASE("Small Multi Map") {
                 { 4, 4 },
                 { 5, 5 },
                 { 6, 6 },
-                { 7, 7 }
+                { 7, 7 },
+                { 7, 8 }
         }));
 
         it = a.erase(a.begin() + 1, a.begin() + 3);
         REQUIRE(it == a.begin() + 1);
-        REQUIRE(a.size() == 3);
+        REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
@@ -1704,7 +1716,20 @@ TEST_CASE("Small Multi Map") {
             {
                 { 1, 1 },
                 { 6, 6 },
-                { 7, 7 }
+                { 7, 7 },
+                { 7, 8 }
+        }));
+
+        REQUIRE(a.erase(7) == 2);
+        REQUIRE(a.size() == 2);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 6, 6 }
         }));
 
         a.clear();

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -1,4 +1,5 @@
 //
+// Copyright (c) 2024 Yat Ho (lagoho7@gmail.com)
 // Copyright (c) 2022 alandefreitas (alandefreitas@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0.

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -1229,3 +1229,526 @@ TEST_CASE("Max Size Map") {
         REQUIRE_FALSE(a >= b);
     }
 }
+
+TEST_CASE("Small Multi Map") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto &sm_map,
+           std::initializer_list<std::pair<const int, int>> il) -> bool {
+        return std::equal(sm_map.begin(), sm_map.end(), il.begin(), il.end());
+    };
+
+    using small_map_type = multimap<int, int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_map_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<std::pair<int, int>> alloc;
+            std::vector<std::pair<int, int>> dv = {
+                { 4, 5 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            small_map_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 3);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(
+                d,
+                {
+                    { 4, 5 },
+                    { 5, 6 },
+                    { 7, 8 }
+            }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_map_type e = {
+                { 1, 2 },
+                { 2, 3 }
+            };
+            REQUIRE(e.size() == 2);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(
+                e,
+                {
+                    { 1, 2 },
+                    { 2, 3 }
+            }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 6, 7 },
+                { 5, 4 },
+                { 4, 5 }
+            };
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 4, 5 },
+                    { 5, 4 },
+                    { 6, 7 }
+            }));
+        }
+
+        SECTION("From another flat map") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a = {
+                { 6, 7 },
+                { 5, 6 },
+                { 4, 5 }
+            };
+
+            small_map_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 3);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 4, 5 },
+                    { 5, 6 },
+                    { 6, 7 }
+            }));
+        }
+
+        SECTION("From iterators") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            std::vector<std::pair<int, int>> v = {
+                { 6, 4 },
+                { 5, 6 },
+                { 4, 6 }
+            };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 4, 6 },
+                    { 5, 6 },
+                    { 6, 4 }
+            }));
+        }
+
+        SECTION("From initializer list") {
+            small_map_type a;
+            REQUIRE(a.empty());
+            a.assign({
+                { 6, 5 },
+                { 5, 2 },
+                { 4, 2 }
+            });
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(
+                a,
+                {
+                    { 4, 2 },
+                    { 5, 2 },
+                    { 6, 5 }
+            }));
+        }
+
+        SECTION("Swap") {
+            small_map_type a = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            small_map_type b = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            std::initializer_list<std::pair<const int, int>> ar = {
+                { 1, 2 },
+                { 3, 4 },
+                { 5, 6 },
+                { 7, 8 }
+            };
+            std::initializer_list<std::pair<const int, int>> br = {
+                {  9, 10 },
+                { 11, 12 },
+                { 13, 14 }
+            };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 4);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_map_type a = {
+            { 1, 2 },
+            { 2, 3 },
+            { 3, 3 }
+        };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin()->first == 1);
+        REQUIRE(std::prev(a.end())->first == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin()->first == 1);
+        REQUIRE(std::prev(a.cend())->first == 3);
+
+        REQUIRE(a.rbegin()->first == 3);
+        REQUIRE(std::prev(a.rend())->first == 1);
+
+        REQUIRE(a.crbegin()->first == 3);
+        REQUIRE(std::prev(a.crend())->first == 1);
+    }
+
+    SECTION("Capacity") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        REQUIRE(a[1] == 1);
+        REQUIRE(a[2] == 2);
+        REQUIRE(a[3] == 3);
+        REQUIRE(a.at(1) == 1);
+        REQUIRE(a.at(2) == 2);
+        REQUIRE(a.at(3) == 3);
+        REQUIRE_THROWS(a.at(4));
+        REQUIRE_THROWS(a.at(5));
+        REQUIRE(a.front().first == 1);
+        REQUIRE(a.back().first == 3);
+        REQUIRE(a.data()->first == 1);
+        REQUIRE((a.data() + 1)->first == 2);
+        REQUIRE((a.data() + 2)->first == 3);
+        REQUIRE((a.data() + a.size() - 1)->first == 3);
+        REQUIRE((a.data() + a.size() - 2)->first == 2);
+        REQUIRE((a.data() + a.size() - 3)->first == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back().first == 4);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        auto p = std::make_pair(5, 5);
+        a.insert(std::move(p));
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+
+        a.erase(5);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+
+        a.emplace(5, 5);
+        REQUIRE(a.back().first == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 },
+                { 5, 5 }
+        }));
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 4, 4 }
+        }));
+
+        auto it = a.emplace_hint(a.lower_bound(10), 10, 10);
+        REQUIRE(it->first == (a.begin() + 4)->first);
+        REQUIRE(a.back().first == 10);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                {  1,  1 },
+                {  2,  2 },
+                {  3,  3 },
+                {  4,  4 },
+                { 10, 10 }
+        }));
+
+        a.erase(10);
+        a.erase(4);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 }
+        }));
+
+        std::initializer_list<std::pair<const int, int>> src = {
+            { 6, 6 },
+            { 5, 5 },
+            { 7, 7 }
+        };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 3, 3 },
+                { 5, 5 },
+                { 6, 6 },
+                { 7, 7 }
+        }));
+
+        a.erase(3);
+        a.erase(5);
+        a.erase(6);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 7, 7 }
+        }));
+
+        a.insert({
+            { 4, 4 },
+            { 5, 5 },
+            { 6, 6 }
+        });
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 2, 2 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 },
+                { 7, 7 }
+        }));
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 4, 4 },
+                { 5, 5 },
+                { 6, 6 },
+                { 7, 7 }
+        }));
+
+        it = a.erase(a.begin() + 1, a.begin() + 3);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(
+            a,
+            {
+                { 1, 1 },
+                { 6, 6 },
+                { 7, 7 }
+        }));
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("Element access errors") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        try {
+            a.at(4);
+        }
+        catch (std::exception &e) {
+            REQUIRE(
+                e.what()
+                == std::string_view("at(): cannot find element in vector map"));
+        }
+    }
+
+    SECTION("Relational Operators") {
+        small_map_type a = {
+            { 1, 1 },
+            { 2, 2 },
+            { 3, 3 }
+        };
+        small_map_type b = {
+            { 2, 2 },
+            { 4, 4 },
+            { 5, 5 }
+        };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}

--- a/test/unit/small_map.cpp
+++ b/test/unit/small_map.cpp
@@ -405,7 +405,7 @@ TEST_CASE("Small Map") {
                 { 4, 4 }
         }));
 
-        auto it = a.emplace_hint(a.lower_bound(10), 10, 10);
+        auto it = a.emplace_hint(a.upper_bound(10), 10, 10);
         REQUIRE(it->first == (a.begin() + 4)->first);
         REQUIRE(a.back().first == 10);
         REQUIRE(a.size() == 5);
@@ -949,7 +949,7 @@ TEST_CASE("Max Size Map") {
                 { 4, 4 }
         }));
 
-        auto it = a.emplace_hint(a.lower_bound(10), 10, 10);
+        auto it = a.emplace_hint(a.upper_bound(10), 10, 10);
         REQUIRE(it->first == (a.begin() + 4)->first);
         REQUIRE(a.back().first == 10);
         REQUIRE(a.size() == 5);

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -269,7 +269,7 @@ TEST_CASE("Small Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
 
-        auto it = a.emplace_hint(a.lower_bound(10), 10);
+        auto it = a.emplace_hint(a.upper_bound(10), 10);
         REQUIRE(it.operator*() == (a.begin() + 4).operator*());
         REQUIRE(a.back() == 10);
         REQUIRE(a.size() == 5);
@@ -600,7 +600,7 @@ TEST_CASE("Max Size Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
 
-        auto it = a.emplace_hint(a.lower_bound(10), 10);
+        auto it = a.emplace_hint(a.upper_bound(10), 10);
         REQUIRE(it.operator*() == (a.begin() + 4).operator*());
         REQUIRE(a.back() == 10);
         REQUIRE(a.size() == 5);

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -1016,3 +1016,666 @@ TEST_CASE("Small Multi Set") {
         REQUIRE_FALSE(a >= b);
     }
 }
+
+TEST_CASE("Small Unordered Set") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto &sm_set, std::initializer_list<int> il) -> bool {
+        return std::equal(sm_set.begin(), sm_set.end(), il.begin(), il.end());
+    };
+
+    using small_set_type = unordered_set<int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_set_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<int> alloc;
+            std::vector<int> dv = { 4, 5, 7 };
+            small_set_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 3);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(d, { 4, 5, 7 }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_set_type e = { 1, 2 };
+            REQUIRE(e.size() == 2);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(e, { 1, 2 }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 5, 4 };
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 4 }));
+        }
+
+        SECTION("From another flat set") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 5, 4 };
+
+            small_set_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 3);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(a, { 6, 5, 4 }));
+        }
+
+        SECTION("From iterators") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            std::vector<int> v = { 6, 5, 4 };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 4 }));
+        }
+
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a.assign({ 6, 5, 4 });
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 4 }));
+        }
+
+        SECTION("Swap") {
+            small_set_type a = { 1, 3, 5, 7 };
+            small_set_type b = { 9, 11, 13 };
+
+            std::initializer_list<int> ar = { 1, 3, 5, 7 };
+            std::initializer_list<int> br = { 9, 11, 13 };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 4);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin().operator*() == 1);
+        REQUIRE(std::prev(a.end()).operator*() == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin().operator*() == 1);
+        REQUIRE(std::prev(a.cend()).operator*() == 3);
+
+        REQUIRE(a.rbegin().operator*() == 3);
+        REQUIRE(std::prev(a.rend()).operator*() == 1);
+
+        REQUIRE(a.crbegin().operator*() == 3);
+        REQUIRE(std::prev(a.crend()).operator*() == 1);
+    }
+
+    SECTION("Capacity") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE(a[0] == 1);
+        REQUIRE(a[1] == 2);
+        REQUIRE(a[2] == 3);
+        REQUIRE(a.at(0) == 1);
+        REQUIRE(a.at(1) == 2);
+        REQUIRE(a.at(2) == 3);
+        REQUIRE_THROWS(a.at(4));
+        REQUIRE_THROWS(a.at(5));
+        REQUIRE(a.front() == 1);
+        REQUIRE(a.back() == 3);
+        REQUIRE(*a.data() == 1);
+        REQUIRE(*(a.data() + 1) == 2);
+        REQUIRE(*(a.data() + 2) == 3);
+        REQUIRE(*(a.data() + a.size() - 1) == 3);
+        REQUIRE(*(a.data() + a.size() - 2) == 2);
+        REQUIRE(*(a.data() + a.size() - 3) == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_set_type a = { 1, 2, 3 };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back() == 4);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(a.count(4) == 1);
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        int p = 5;
+        a.insert(std::move(p));
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
+
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(a.count(5) == 0);
+
+        a.emplace(5);
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+
+        auto it = a.emplace_hint(a.begin() + 3, 10);
+        REQUIRE(it.operator*() == (a.begin() + 3).operator*());
+        REQUIRE(a.back() == 4);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 10, 4 }));
+        REQUIRE(a.count(10) == 1);
+
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3 }));
+        REQUIRE(a.count(10) == 0);
+
+        std::initializer_list<int> src = { 6, 5, 7 };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 6, 5, 7 }));
+
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 7 }));
+
+        a.insert({ 4, 5, 6 });
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 7, 4, 5, 6 }));
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 7, 4, 5, 6 }));
+
+        it = a.erase(a.begin() + 1, a.begin() + 3);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 5, 6 }));
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("Find in small set") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.find(1) == a.begin());
+        REQUIRE(a.find(4) == a.end());
+    }
+
+    SECTION("Find in big set") {
+        small_set_type a = {};
+        for (int i = 0; i < 1000; ++i) {
+            a.insert(i);
+        }
+
+        REQUIRE(a.find(0) == a.begin());
+        REQUIRE(a.find(1000) == a.end());
+    }
+
+    SECTION("Element access errors") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE_THROWS(a.at(4));
+    }
+
+    SECTION("Relational Operators") {
+        small_set_type a = { 1, 2, 3 };
+        small_set_type b = { 2, 4, 5 };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}
+
+TEST_CASE("Small Unordered Multi Set") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto &sm_set, std::initializer_list<int> il) -> bool {
+        return std::equal(sm_set.begin(), sm_set.end(), il.begin(), il.end());
+    };
+
+    using small_set_type = unordered_multiset<int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_set_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<int> alloc;
+            std::vector<int> dv = { 4, 5, 7, 7 };
+            small_set_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 4);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(d, { 4, 5, 7, 7 }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_set_type e = { 1, 2, 2 };
+            REQUIRE(e.size() == 3);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(e, { 1, 2, 2 }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 5, 5, 4 };
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 5, 4 }));
+        }
+
+        SECTION("From another flat set") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 6, 5, 4 };
+
+            small_set_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 4);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(a, { 6, 6, 5, 4 }));
+        }
+
+        SECTION("From iterators") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            std::vector<int> v = { 6, 5, 4, 4 };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 4, 4 }));
+        }
+
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a.assign({ 6, 5, 5, 4 });
+            REQUIRE(a.size() == 4);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 6, 5, 5, 4 }));
+        }
+
+        SECTION("Swap") {
+            small_set_type a = { 1, 1, 3, 5, 7 };
+            small_set_type b = { 9, 11, 13 };
+
+            std::initializer_list<int> ar = { 1, 1, 3, 5, 7 };
+            std::initializer_list<int> br = { 9, 11, 13 };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 5);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 5);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 5);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin().operator*() == 1);
+        REQUIRE(std::prev(a.end()).operator*() == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin().operator*() == 1);
+        REQUIRE(std::prev(a.cend()).operator*() == 3);
+
+        REQUIRE(a.rbegin().operator*() == 3);
+        REQUIRE(std::prev(a.rend()).operator*() == 1);
+
+        REQUIRE(a.crbegin().operator*() == 3);
+        REQUIRE(std::prev(a.crend()).operator*() == 1);
+    }
+
+    SECTION("Capacity") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_set_type a = { 1, 2, 2, 3 };
+        REQUIRE(a[0] == 1);
+        REQUIRE(a[1] == 2);
+        REQUIRE(a[2] == 2);
+        REQUIRE(a[3] == 3);
+        REQUIRE(a.at(0) == 1);
+        REQUIRE(a.at(1) == 2);
+        REQUIRE(a.at(2) == 2);
+        REQUIRE(a.at(3) == 3);
+        REQUIRE_THROWS(a.at(4));
+        REQUIRE_THROWS(a.at(5));
+        REQUIRE(a.front() == 1);
+        REQUIRE(a.back() == 3);
+        REQUIRE(*a.data() == 1);
+        REQUIRE(*(a.data() + 1) == 2);
+        REQUIRE(*(a.data() + 2) == 2);
+        REQUIRE(*(a.data() + 3) == 3);
+        REQUIRE(*(a.data() + a.size() - 1) == 3);
+        REQUIRE(*(a.data() + a.size() - 2) == 2);
+        REQUIRE(*(a.data() + a.size() - 3) == 2);
+        REQUIRE(*(a.data() + a.size() - 4) == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_set_type a = { 1, 2, 3 };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back() == 4);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
+        REQUIRE(a.count(4) == 2);
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        int p = 5;
+        a.insert(std::move(p));
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
+
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
+        REQUIRE(a.count(5) == 0);
+
+        a.emplace(5);
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
+
+        auto it = a.emplace_hint(a.begin() + 4, 10);
+        REQUIRE(it.operator*() == (a.begin() + 4).operator*());
+        REQUIRE(a.back() == 4);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 10, 4 }));
+        REQUIRE(a.count(10) == 1);
+
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 2);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3 }));
+        REQUIRE(a.count(4) == 0);
+
+        std::initializer_list<int> src = { 6, 5, 7 };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 6, 5, 7 }));
+
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 7 }));
+
+        a.insert({ 4, 5, 6 });
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 7, 4, 5, 6 }));
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 7, 4, 5, 6 }));
+
+        it = a.erase(a.begin() + 1, a.begin() + 3);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 5, 6 }));
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("Element access errors") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE_THROWS(a.at(4));
+    }
+
+    SECTION("Relational Operators") {
+        small_set_type a = { 1, 2, 3 };
+        small_set_type b = { 2, 4, 5 };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -335,6 +335,23 @@ TEST_CASE("Small Set") {
         REQUIRE(equal_il(a, {}));
     }
 
+    SECTION("Find in small set") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.find(1) == a.begin());
+        REQUIRE(a.find(4) == a.end());
+    }
+
+    SECTION("Find in big set") {
+        small_set_type a = {};
+        for (int i = 0; i < 1000; ++i) {
+            a.insert(i);
+        }
+
+        REQUIRE(a.find(0) == a.begin());
+        REQUIRE(a.find(1000) == a.end());
+    }
+
     SECTION("Element access errors") {
         small_set_type a = { 1, 2, 3 };
         REQUIRE_THROWS(a.at(4));

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -247,7 +247,7 @@ TEST_CASE("Small Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
 
-        a.erase(5);
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -278,8 +278,8 @@ TEST_CASE("Small Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 10 }));
 
-        a.erase(10);
-        a.erase(4);
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
@@ -294,9 +294,10 @@ TEST_CASE("Small Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 5, 6, 7 }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() >= 3);
@@ -578,7 +579,7 @@ TEST_CASE("Max Size Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
 
-        a.erase(5);
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -609,8 +610,8 @@ TEST_CASE("Max Size Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 10 }));
 
-        a.erase(10);
-        a.erase(4);
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 1);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -625,9 +626,10 @@ TEST_CASE("Max Size Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 5, 6 }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
         REQUIRE(a.size() == 2);
         REQUIRE(a.max_size() == 5);
         REQUIRE(a.capacity() == 5);
@@ -711,19 +713,19 @@ TEST_CASE("Small Multi Set") {
 
         SECTION("From Iterators") {
             std::allocator<int> alloc;
-            std::vector<int> dv = { 4, 5, 7 };
+            std::vector<int> dv = { 4, 5, 7, 7 };
             small_set_type d(dv.begin(), dv.end(), alloc);
-            REQUIRE(d.size() == 3);
+            REQUIRE(d.size() == 4);
             REQUIRE_FALSE(d.empty());
-            REQUIRE(equal_il(d, { 4, 5, 7 }));
+            REQUIRE(equal_il(d, { 4, 5, 7, 7 }));
             REQUIRE(d.get_allocator() == alloc);
         }
 
         SECTION("From initializer list") {
-            small_set_type e = { 1, 2 };
-            REQUIRE(e.size() == 2);
+            small_set_type e = { 1, 2, 2 };
+            REQUIRE(e.size() == 3);
             REQUIRE_FALSE(e.empty());
-            REQUIRE(equal_il(e, { 1, 2 }));
+            REQUIRE(equal_il(e, { 1, 2, 2 }));
         }
     }
 
@@ -731,54 +733,54 @@ TEST_CASE("Small Multi Set") {
         SECTION("From initializer list") {
             small_set_type a;
             REQUIRE(a.empty());
-            a = { 6, 5, 4 };
-            REQUIRE(a.size() == 3);
+            a = { 6, 5, 5, 4 };
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
-            REQUIRE(equal_il(a, { 4, 5, 6 }));
+            REQUIRE(equal_il(a, { 4, 5, 5, 6 }));
         }
 
         SECTION("From another flat set") {
             small_set_type a;
             REQUIRE(a.empty());
-            a = { 6, 5, 4 };
+            a = { 6, 6, 5, 4 };
 
             small_set_type b;
             REQUIRE(b.empty());
             b = a;
-            REQUIRE(b.size() == 3);
+            REQUIRE(b.size() == 4);
             REQUIRE_FALSE(b.empty());
             REQUIRE(a == b);
-            REQUIRE(equal_il(a, { 4, 5, 6 }));
+            REQUIRE(equal_il(a, { 4, 5, 6, 6 }));
         }
 
         SECTION("From iterators") {
             small_set_type a;
             REQUIRE(a.empty());
-            std::vector<int> v = { 6, 5, 4 };
+            std::vector<int> v = { 6, 5, 4, 4 };
             a.assign(v.begin(), v.end());
-            REQUIRE(a.size() == 3);
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
-            REQUIRE(equal_il(a, { 4, 5, 6 }));
+            REQUIRE(equal_il(a, { 4, 4, 5, 6 }));
         }
 
         SECTION("From initializer list") {
             small_set_type a;
             REQUIRE(a.empty());
-            a.assign({ 6, 5, 4 });
-            REQUIRE(a.size() == 3);
+            a.assign({ 6, 5, 5, 4 });
+            REQUIRE(a.size() == 4);
             REQUIRE_FALSE(a.empty());
-            REQUIRE(equal_il(a, { 4, 5, 6 }));
+            REQUIRE(equal_il(a, { 4, 5, 5, 6 }));
         }
 
         SECTION("Swap") {
-            small_set_type a = { 1, 3, 5, 7 };
+            small_set_type a = { 1, 1, 3, 5, 7 };
             small_set_type b = { 9, 11, 13 };
 
-            std::initializer_list<int> ar = { 1, 3, 5, 7 };
+            std::initializer_list<int> ar = { 1, 1, 3, 5, 7 };
             std::initializer_list<int> br = { 9, 11, 13 };
 
             REQUIRE_FALSE(a.empty());
-            REQUIRE(a.size() == 4);
+            REQUIRE(a.size() == 5);
             REQUIRE(equal_il(a, ar));
             REQUIRE_FALSE(b.empty());
             REQUIRE(b.size() == 3);
@@ -790,13 +792,13 @@ TEST_CASE("Small Multi Set") {
             REQUIRE(a.size() == 3);
             REQUIRE(equal_il(a, br));
             REQUIRE_FALSE(b.empty());
-            REQUIRE(b.size() == 4);
+            REQUIRE(b.size() == 5);
             REQUIRE(equal_il(b, ar));
 
             std::swap(a, b);
 
             REQUIRE_FALSE(a.empty());
-            REQUIRE(a.size() == 4);
+            REQUIRE(a.size() == 5);
             REQUIRE(equal_il(a, ar));
             REQUIRE_FALSE(b.empty());
             REQUIRE(b.size() == 3);
@@ -853,81 +855,85 @@ TEST_CASE("Small Multi Set") {
     }
 
     SECTION("Element access") {
-        small_set_type a = { 1, 2, 3 };
+        small_set_type a = { 1, 2, 2, 3 };
         REQUIRE(a[0] == 1);
         REQUIRE(a[1] == 2);
-        REQUIRE(a[2] == 3);
+        REQUIRE(a[2] == 2);
+        REQUIRE(a[3] == 3);
         REQUIRE(a.at(0) == 1);
         REQUIRE(a.at(1) == 2);
-        REQUIRE(a.at(2) == 3);
+        REQUIRE(a.at(2) == 2);
+        REQUIRE(a.at(3) == 3);
         REQUIRE_THROWS(a.at(4));
         REQUIRE_THROWS(a.at(5));
         REQUIRE(a.front() == 1);
         REQUIRE(a.back() == 3);
         REQUIRE(*a.data() == 1);
         REQUIRE(*(a.data() + 1) == 2);
-        REQUIRE(*(a.data() + 2) == 3);
+        REQUIRE(*(a.data() + 2) == 2);
+        REQUIRE(*(a.data() + 3) == 3);
         REQUIRE(*(a.data() + a.size() - 1) == 3);
         REQUIRE(*(a.data() + a.size() - 2) == 2);
-        REQUIRE(*(a.data() + a.size() - 3) == 1);
+        REQUIRE(*(a.data() + a.size() - 3) == 2);
+        REQUIRE(*(a.data() + a.size() - 4) == 1);
     }
 
     SECTION("Modifiers") {
         small_set_type a = { 1, 2, 3 };
         a.insert({ 4, 4 });
         REQUIRE(a.back() == 4);
-        REQUIRE(a.size() == 4);
+        REQUIRE(a.size() == 5);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
 
         // NOLINTNEXTLINE(performance-move-const-arg)
         int p = 5;
         a.insert(std::move(p));
         REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
+
+        REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 5);
         REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
+        REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
-
-        a.erase(5);
-        REQUIRE(a.size() == 4);
-        REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
-        REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
 
         a.emplace(5);
         REQUIRE(a.back() == 5);
-        REQUIRE(a.size() == 5);
-        REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
         REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
 
         a.erase(std::prev(a.end()));
-        REQUIRE(a.size() == 4);
-        REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
-        REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
-
-        auto it = a.emplace_hint(a.lower_bound(10), 10);
-        REQUIRE(it.operator*() == (a.begin() + 4).operator*());
-        REQUIRE(a.back() == 10);
         REQUIRE(a.size() == 5);
         REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
+        REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
-        REQUIRE(equal_il(a, { 1, 2, 3, 4, 10 }));
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
 
-        a.erase(10);
-        a.erase(4);
+        auto it = a.emplace_hint(a.lower_bound(10), 10);
+        REQUIRE(it.operator*() == (a.begin() + 5).operator*());
+        REQUIRE(a.back() == 10);
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 10 }));
+
+        REQUIRE(a.erase(10) == 1);
+        REQUIRE(a.erase(4) == 2);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
-        REQUIRE(a.capacity() == 5);
+        REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3 }));
 
@@ -939,9 +945,10 @@ TEST_CASE("Small Multi Set") {
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 5, 6, 7 }));
 
-        a.erase(3);
-        a.erase(5);
-        a.erase(6);
+        REQUIRE(a.erase(3) == 1);
+        REQUIRE(a.erase(5) == 1);
+        REQUIRE(a.erase(6) == 1);
+        REQUIRE(a.erase(8) == 0);
         REQUIRE(a.size() == 3);
         REQUIRE(a.max_size() > 5);
         REQUIRE(a.capacity() >= 3);
@@ -978,23 +985,6 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 5);
         REQUIRE(a.empty());
         REQUIRE(equal_il(a, {}));
-    }
-
-    SECTION("Find in small set") {
-        small_set_type a = { 1, 2, 3 };
-
-        REQUIRE(a.find(1) == a.begin());
-        REQUIRE(a.find(4) == a.end());
-    }
-
-    SECTION("Find in big set") {
-        small_set_type a = {};
-        for (int i = 0; i < 1000; ++i) {
-            a.insert(i);
-        }
-
-        REQUIRE(a.find(0) == a.begin());
-        REQUIRE(a.find(1000) == a.end());
     }
 
     SECTION("Element access errors") {

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -1,4 +1,5 @@
 //
+// Copyright (c) 2024 Yat Ho (lagoho7@gmail.com)
 // Copyright (c) 2022 alandefreitas (alandefreitas@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0.

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -236,6 +236,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(a.count(4) == 1);
 
         // NOLINTNEXTLINE(performance-move-const-arg)
         int p = 5;
@@ -246,6 +247,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
 
         REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 4);
@@ -253,6 +255,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+        REQUIRE(a.count(5) == 0);
 
         a.emplace(5);
         REQUIRE(a.back() == 5);
@@ -261,6 +264,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
 
         a.erase(std::prev(a.end()));
         REQUIRE(a.size() == 4);
@@ -277,6 +281,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 10 }));
+        REQUIRE(a.count(10) == 1);
 
         REQUIRE(a.erase(10) == 1);
         REQUIRE(a.erase(4) == 1);
@@ -285,6 +290,7 @@ TEST_CASE("Small Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3 }));
+        REQUIRE(a.count(10) == 0);
 
         std::initializer_list<int> src = { 6, 5, 7 };
         a.insert(src.begin(), src.end());
@@ -887,6 +893,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() == 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
+        REQUIRE(a.count(4) == 2);
 
         // NOLINTNEXTLINE(performance-move-const-arg)
         int p = 5;
@@ -897,6 +904,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 6);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
 
         REQUIRE(a.erase(5) == 1);
         REQUIRE(a.size() == 5);
@@ -904,6 +912,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 4 }));
+        REQUIRE(a.count(5) == 0);
 
         a.emplace(5);
         REQUIRE(a.back() == 5);
@@ -912,6 +921,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 6);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 5 }));
+        REQUIRE(a.count(5) == 1);
 
         a.erase(std::prev(a.end()));
         REQUIRE(a.size() == 5);
@@ -928,6 +938,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 6);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3, 4, 4, 10 }));
+        REQUIRE(a.count(10) == 1);
 
         REQUIRE(a.erase(10) == 1);
         REQUIRE(a.erase(4) == 2);
@@ -936,6 +947,7 @@ TEST_CASE("Small Multi Set") {
         REQUIRE(a.capacity() >= 5);
         REQUIRE_FALSE(a.empty());
         REQUIRE(equal_il(a, { 1, 2, 3 }));
+        REQUIRE(a.count(4) == 0);
 
         std::initializer_list<int> src = { 6, 5, 7 };
         a.insert(src.begin(), src.end());

--- a/test/unit/small_set.cpp
+++ b/test/unit/small_set.cpp
@@ -683,3 +683,334 @@ TEST_CASE("Max Size Set") {
         REQUIRE_FALSE(a >= b);
     }
 }
+
+TEST_CASE("Small Multi Set") {
+    using namespace small;
+
+    auto equal_il =
+        [](const auto &sm_set, std::initializer_list<int> il) -> bool {
+        return std::equal(sm_set.begin(), sm_set.end(), il.begin(), il.end());
+    };
+
+    using small_set_type = multiset<int, 5>;
+
+    SECTION("Constructor") {
+        SECTION("Default") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+        }
+
+        SECTION("Allocator") {
+            std::allocator<int> alloc;
+            small_set_type a(alloc);
+            REQUIRE(a.empty());
+            REQUIRE(equal_il(a, {}));
+            REQUIRE(a.get_allocator() == alloc);
+        }
+
+        SECTION("From Iterators") {
+            std::allocator<int> alloc;
+            std::vector<int> dv = { 4, 5, 7 };
+            small_set_type d(dv.begin(), dv.end(), alloc);
+            REQUIRE(d.size() == 3);
+            REQUIRE_FALSE(d.empty());
+            REQUIRE(equal_il(d, { 4, 5, 7 }));
+            REQUIRE(d.get_allocator() == alloc);
+        }
+
+        SECTION("From initializer list") {
+            small_set_type e = { 1, 2 };
+            REQUIRE(e.size() == 2);
+            REQUIRE_FALSE(e.empty());
+            REQUIRE(equal_il(e, { 1, 2 }));
+        }
+    }
+
+    SECTION("Assign") {
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 5, 4 };
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 4, 5, 6 }));
+        }
+
+        SECTION("From another flat set") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a = { 6, 5, 4 };
+
+            small_set_type b;
+            REQUIRE(b.empty());
+            b = a;
+            REQUIRE(b.size() == 3);
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(a == b);
+            REQUIRE(equal_il(a, { 4, 5, 6 }));
+        }
+
+        SECTION("From iterators") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            std::vector<int> v = { 6, 5, 4 };
+            a.assign(v.begin(), v.end());
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 4, 5, 6 }));
+        }
+
+        SECTION("From initializer list") {
+            small_set_type a;
+            REQUIRE(a.empty());
+            a.assign({ 6, 5, 4 });
+            REQUIRE(a.size() == 3);
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(equal_il(a, { 4, 5, 6 }));
+        }
+
+        SECTION("Swap") {
+            small_set_type a = { 1, 3, 5, 7 };
+            small_set_type b = { 9, 11, 13 };
+
+            std::initializer_list<int> ar = { 1, 3, 5, 7 };
+            std::initializer_list<int> br = { 9, 11, 13 };
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+
+            a.swap(b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 3);
+            REQUIRE(equal_il(a, br));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 4);
+            REQUIRE(equal_il(b, ar));
+
+            std::swap(a, b);
+
+            REQUIRE_FALSE(a.empty());
+            REQUIRE(a.size() == 4);
+            REQUIRE(equal_il(a, ar));
+            REQUIRE_FALSE(b.empty());
+            REQUIRE(b.size() == 3);
+            REQUIRE(equal_il(b, br));
+        }
+    }
+
+    SECTION("Iterators") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.begin().operator->() == a.data());
+        REQUIRE(a.end().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.end().operator->() == a.data() + a.capacity());
+        REQUIRE(a.begin().operator*() == 1);
+        REQUIRE(std::prev(a.end()).operator*() == 3);
+
+        REQUIRE(a.cbegin().operator->() == a.data());
+        REQUIRE(a.cend().operator->() == a.data() + a.size());
+        REQUIRE_FALSE(a.cend().operator->() == a.data() + a.capacity());
+        REQUIRE(a.cbegin().operator*() == 1);
+        REQUIRE(std::prev(a.cend()).operator*() == 3);
+
+        REQUIRE(a.rbegin().operator*() == 3);
+        REQUIRE(std::prev(a.rend()).operator*() == 1);
+
+        REQUIRE(a.crbegin().operator*() == 3);
+        REQUIRE(std::prev(a.crend()).operator*() == 1);
+    }
+
+    SECTION("Capacity") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.reserve(10);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() >= 10);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == 5);
+
+        a.shrink_to_fit();
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(a.capacity() == (std::max)(size_t(5), a.size()));
+    }
+
+    SECTION("Element access") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE(a[0] == 1);
+        REQUIRE(a[1] == 2);
+        REQUIRE(a[2] == 3);
+        REQUIRE(a.at(0) == 1);
+        REQUIRE(a.at(1) == 2);
+        REQUIRE(a.at(2) == 3);
+        REQUIRE_THROWS(a.at(4));
+        REQUIRE_THROWS(a.at(5));
+        REQUIRE(a.front() == 1);
+        REQUIRE(a.back() == 3);
+        REQUIRE(*a.data() == 1);
+        REQUIRE(*(a.data() + 1) == 2);
+        REQUIRE(*(a.data() + 2) == 3);
+        REQUIRE(*(a.data() + a.size() - 1) == 3);
+        REQUIRE(*(a.data() + a.size() - 2) == 2);
+        REQUIRE(*(a.data() + a.size() - 3) == 1);
+    }
+
+    SECTION("Modifiers") {
+        small_set_type a = { 1, 2, 3 };
+        a.insert({ 4, 4 });
+        REQUIRE(a.back() == 4);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        int p = 5;
+        a.insert(std::move(p));
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+
+        a.erase(5);
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+
+        a.emplace(5);
+        REQUIRE(a.back() == 5);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 5 }));
+
+        a.erase(std::prev(a.end()));
+        REQUIRE(a.size() == 4);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4 }));
+
+        auto it = a.emplace_hint(a.lower_bound(10), 10);
+        REQUIRE(it.operator*() == (a.begin() + 4).operator*());
+        REQUIRE(a.back() == 10);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 4, 10 }));
+
+        a.erase(10);
+        a.erase(4);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() == 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3 }));
+
+        std::initializer_list<int> src = { 6, 5, 7 };
+        a.insert(src.begin(), src.end());
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() >= 6);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 3, 5, 6, 7 }));
+
+        a.erase(3);
+        a.erase(5);
+        a.erase(6);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 3);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 7 }));
+
+        a.insert({ 4, 5, 6 });
+        REQUIRE(a.size() == 6);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 6);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 2, 4, 5, 6, 7 }));
+
+        it = a.erase(a.begin() + 1);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 5);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 4, 5, 6, 7 }));
+
+        it = a.erase(a.begin() + 1, a.begin() + 3);
+        REQUIRE(it == a.begin() + 1);
+        REQUIRE(a.size() == 3);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE_FALSE(a.empty());
+        REQUIRE(equal_il(a, { 1, 6, 7 }));
+
+        a.clear();
+        // NOLINTNEXTLINE(readability-container-size-empty)
+        REQUIRE(a.size() == 0);
+        REQUIRE(a.max_size() > 5);
+        REQUIRE(a.capacity() >= 5);
+        REQUIRE(a.empty());
+        REQUIRE(equal_il(a, {}));
+    }
+
+    SECTION("Find in small set") {
+        small_set_type a = { 1, 2, 3 };
+
+        REQUIRE(a.find(1) == a.begin());
+        REQUIRE(a.find(4) == a.end());
+    }
+
+    SECTION("Find in big set") {
+        small_set_type a = {};
+        for (int i = 0; i < 1000; ++i) {
+            a.insert(i);
+        }
+
+        REQUIRE(a.find(0) == a.begin());
+        REQUIRE(a.find(1000) == a.end());
+    }
+
+    SECTION("Element access errors") {
+        small_set_type a = { 1, 2, 3 };
+        REQUIRE_THROWS(a.at(4));
+    }
+
+    SECTION("Relational Operators") {
+        small_set_type a = { 1, 2, 3 };
+        small_set_type b = { 2, 4, 5 };
+
+        REQUIRE_FALSE(a == b);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(a <= b);
+        REQUIRE_FALSE(a > b);
+        REQUIRE_FALSE(a >= b);
+    }
+}


### PR DESCRIPTION
Fixes #34
Fixes #35
Fixes #37
Fixes #39
Fixes #40

To make sure the changes are easy to trace, I was going to split this into 3 PRs, because I am used to squash merging. But since it looks like this repo is using rebase merge, I figured I can just lump all changes in to 1 PR.