### PR TITLE
fix: replace `std::for_each_n` for gcc 8 build failure

### DIFF
--- a/include/small/vector.hpp
+++ b/include/small/vector.hpp
@@ -1087,10 +1087,7 @@ namespace small {
                 // be running the destructor on exact byte copies of in-use
                 // elements, and you might free their internal buffers (oh no!).
                 if constexpr (!std::is_trivially_destructible_v<value_type>) {
-                    std::for_each_n(
-                        crbegin(),
-                        n_erase,
-                        [](value_type const &ele) { ele.~value_type(); });
+                    std::destroy_n(crbegin(), n_erase);
                 }
             }
 


### PR DESCRIPTION
Our NetBSD CI over at the Transmission project found that `std::for_each_n` is not supported by GCC 8 for whatever reason.

The solution in this PR is already tested to build successfully.

```
In file included from ../../third-party/small/include/small/map.hpp:11,
                 from ../../libtransmission/announce-list.cc:11:
../../third-party/small/include/small/vector.hpp: In member function 'constexpr small::vector<T, N, Allocator, AllowHeap, SizeType, GrowthFactor>::iterator small::vector<T, N, Allocator, AllowHeap, SizeType, GrowthFactor>::erase(small::vector<T, N, Allocator, AllowHeap, SizeType, GrowthFactor>::const_iterator, small::vector<T, N, Allocator, AllowHeap, SizeType, GrowthFactor>::const_iterator)':
../../third-party/small/include/small/vector.hpp:1090:26: error: 'for_each_n' is not a member of 'std'
                     std::for_each_n(
                          ^~~~~~~~~~
../../third-party/small/include/small/vector.hpp:1090:26: note: suggested alternative: 'for_each'
                     std::for_each_n(
                          ^~~~~~~~~~
                          for_each
Process exited with code 1
```