### PR TITLE
fix: mark headers as system when not master project

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,8 +17,8 @@ add_library(small::small ALIAS small)
 target_compile_features(small INTERFACE cxx_std_17)
 
 # Include directories (development and installation)
-target_include_directories(small
-        INTERFACE $<BUILD_INTERFACE:${SMALL_ROOT_DIR}/include>
+target_include_directories(small ${warning_guard} INTERFACE
+        $<BUILD_INTERFACE:${SMALL_ROOT_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Compiler options


### PR DESCRIPTION
The infrastructure was there, but it was never used. 😄 