### PR TITLE
feat: support contiguous iterator/container concepts

### DIFF
--- a/include/small/detail/iterator/pointer_wrapper.hpp
+++ b/include/small/detail/iterator/pointer_wrapper.hpp
@@ -28,6 +28,11 @@ namespace small {
             typedef
                 typename std::iterator_traits<iterator_type>::iterator_category
                     iterator_category;
+#if cpp_lib_ranges >= 201811L
+            typedef
+                typename std::iterator_traits<iterator_type>::iterator_concept
+                    iterator_concept;
+#endif
             typedef typename std::iterator_traits<iterator_type>::value_type
                 value_type;
             typedef


### PR DESCRIPTION
Make `std::ranges::contiguous_range<small::vector>` evaluate to `true`.

This lets `small::vector` be passed into `std::span` constructor for example.